### PR TITLE
"DecoratedCustomViewStyle" removed from TTSNotification

### DIFF
--- a/EBookDroid/src/com/foobnix/tts/TTSNotification.java
+++ b/EBookDroid/src/com/foobnix/tts/TTSNotification.java
@@ -125,7 +125,7 @@ public class TTSNotification {
                     //.addAction(R.drawable.glyphicons_177_forward, context.getString(R.string.stop), stopDestroy)//
                     //.setContentTitle(fileMetaBookName) //
                     //.setContentText(pageNumber) //
-                    .setStyle(new NotificationCompat.DecoratedCustomViewStyle())//
+                    //.setStyle(new NotificationCompat.DecoratedCustomViewStyle())//
                     .setCustomContentView(remoteViews); ///
 
             Notification n = builder.build(); //


### PR DESCRIPTION
### Bad display of notifications when using DecoratedCustomViewStyle

| With<br>DecoratedCustomViewStyle | Without<br>DecoratedCustomViewStyle |
|--------|-------|
|   <img src="https://user-images.githubusercontent.com/1471609/45859582-40342e00-bd8d-11e8-86b9-3744f6f27104.png" width = 300/>     |   <img src="https://user-images.githubusercontent.com/1471609/45859620-6c4faf00-bd8d-11e8-999b-fb044951d4ae.png" width = 300/>    |


P.S. Devices for reproduce 
Samsung Galaxy A5