### PR TITLE
Fixed user confuse with "Default links color"

### DIFF
--- a/EBookDroid/src/com/foobnix/pdf/info/model/BookCSS.java
+++ b/EBookDroid/src/com/foobnix/pdf/info/model/BookCSS.java
@@ -25,8 +25,12 @@ import com.foobnix.ui2.AppDB;
 
 import android.content.Context;
 import android.content.SharedPreferences;
+import android.graphics.Color;
 import android.graphics.Typeface;
 import android.os.Environment;
+import android.text.TextUtils;
+
+import org.ebookdroid.LibreraApp;
 
 public class BookCSS {
 
@@ -119,8 +123,9 @@ public class BookCSS {
         isAutoHypens = true;
         hypenLang = "en";
 
-        linkColorDay = LINK_COLOR_UNIVERSAL;
-        linkColorNight = LINK_COLOR_UNIVERSAL;
+        linkColorDay = null;
+        linkColorNight = null;
+
         customCSS2 = //
                 "code,pre,pre>* {white-space: pre-line;}\n" + //
                         ""//
@@ -311,6 +316,31 @@ public class BookCSS {
 
     private Collection<FontPack> getAllFontsFiltered(String path) {
         return getAllFontsFiltered(path, false);
+    }
+
+    public String getLinkColorNight(){
+        if (TextUtils.isEmpty(linkColorNight)){
+            return getBaseLinkColor();
+        }else{
+            return linkColorNight;
+        }
+    }
+
+    public String getLinkColorDay(){
+        if (TextUtils.isEmpty(linkColorDay)){
+            return getBaseLinkColor();
+        }else{
+            return linkColorDay;
+        }
+    }
+
+    public String getBaseLinkColor() {
+        int color = AppState.get().isUiTextColor ?
+                AppState.get().uiTextColor :
+                LibreraApp.context.getTheme().obtainStyledAttributes(new int[]{android.R.attr.textColorLink})
+                        .getColor(0, Color.parseColor(LINK_COLOR_UNIVERSAL));
+
+        return "#" + Integer.toHexString(color).substring(2);
     }
 
     private Collection<FontPack> getAllFontsFiltered(String path, final boolean excludeNoto) {
@@ -536,9 +566,9 @@ public class BookCSS {
         if (documentStyle == STYLES_DOC_AND_USER || documentStyle == STYLES_ONLY_USER) {
 
             if (AppState.get().isDayNotInvert) {
-                builder.append("a{color:" + linkColorDay + " !important;}");
+                builder.append("a{color:" + getLinkColorDay() + " !important;}");
             } else {
-                builder.append("a{color:" + linkColorNight + " !important;}");
+                builder.append("a{color:" + getLinkColorNight() + " !important;}");
             }
 
             // FONTS BEGIN

--- a/EBookDroid/src/com/foobnix/pdf/info/view/DragingDialogs.java
+++ b/EBookDroid/src/com/foobnix/pdf/info/view/DragingDialogs.java
@@ -3715,7 +3715,7 @@ public class DragingDialogs {
                 // link color
                 final CustomColorView linkColorDay = (CustomColorView) inflate.findViewById(R.id.linkColorDay);
                 linkColorDay.withDefaultColors(Color.parseColor(BookCSS.LINK_COLOR_DAY), Color.parseColor(BookCSS.LINK_COLOR_UNIVERSAL));
-                linkColorDay.init(Color.parseColor(BookCSS.get().linkColorDay));
+                linkColorDay.init(Color.parseColor(BookCSS.get().getLinkColorDay()));
                 linkColorDay.setOnColorChanged(new StringResponse() {
 
                     @Override
@@ -3727,7 +3727,7 @@ public class DragingDialogs {
 
                 final CustomColorView linkColorNight = (CustomColorView) inflate.findViewById(R.id.linkColorNight);
                 linkColorNight.withDefaultColors(Color.parseColor(BookCSS.LINK_COLOR_NIGHT), Color.parseColor(BookCSS.LINK_COLOR_UNIVERSAL));
-                linkColorNight.init(Color.parseColor(BookCSS.get().linkColorNight));
+                linkColorNight.init(Color.parseColor(BookCSS.get().getLinkColorNight()));
                 linkColorNight.setOnColorChanged(new StringResponse() {
 
                     @Override
@@ -3768,8 +3768,8 @@ public class DragingDialogs {
 
                                 emptyLine.reset(BookCSS.get().emptyLine);
 
-                                linkColorDay.init(Color.parseColor(BookCSS.get().linkColorDay));
-                                linkColorNight.init(Color.parseColor(BookCSS.get().linkColorNight));
+                                linkColorDay.init(Color.parseColor(BookCSS.get().getLinkColorDay()));
+                                linkColorNight.init(Color.parseColor(BookCSS.get().getLinkColorNight()));
                             }
                         });
 

--- a/EBookDroid/src/com/foobnix/tts/TTSControlsView.java
+++ b/EBookDroid/src/com/foobnix/tts/TTSControlsView.java
@@ -62,7 +62,7 @@ public class TTSControlsView extends FrameLayout {
         ttsDialog = (ImageView) view.findViewById(R.id.ttsDialog);
         ttsDialog.setVisibility(View.GONE);
 
-        int color = Color.parseColor(AppState.get().isDayNotInvert ? BookCSS.get().linkColorDay : BookCSS.get().linkColorNight);
+        int color = Color.parseColor(AppState.get().isDayNotInvert ? BookCSS.get().getLinkColorDay() : BookCSS.get().getLinkColorNight());
 
         TintUtil.setTintImageWithAlpha(ttsStop, color);
         TintUtil.setTintImageWithAlpha(ttsPlayPause, color);


### PR DESCRIPTION
### Suggestion for improvement
If the user changes the "Links Color" in the basic settings, then the color of links in the books will not change. Not all users know about the special settings `linkColorNight`/`linkColorDay `in the menu "Reading Settings". For them it looks like a bug.


I suggest for those who have **never** changed the `linkColorNight` /` linkColorDay` to assign a link color from the basic settings.


<img src="https://user-images.githubusercontent.com/1471609/45950599-b608f580-c02a-11e8-960e-be1895aea985.gif" width=300 />
