### PR TITLE
Search process cancellation fixed.

### DIFF
--- a/EBookDroid/src/com/foobnix/pdf/search/activity/HorizontalViewActivity.java
+++ b/EBookDroid/src/com/foobnix/pdf/search/activity/HorizontalViewActivity.java
@@ -1281,7 +1281,7 @@ public class HorizontalViewActivity extends AdsFragmentActivity {
     protected void onPause() {
         super.onPause();
         AppState.get().save(this);
-        TempHolder.isSeaching = false;
+        TempHolder.isSearching.set(false);
         handler.postDelayed(closeRunnable, AppState.APP_CLOSE_AUTOMATIC);
         handlerTimer.removeCallbacks(updateTimePower);
 

--- a/EBookDroid/src/com/foobnix/pdf/search/activity/PageImaveView.java
+++ b/EBookDroid/src/com/foobnix/pdf/search/activity/PageImaveView.java
@@ -512,7 +512,7 @@ public class PageImaveView extends View {
                 if (isLognPress) {
                     selectText(event.getX(), event.getY(), xInit, yInit);
                 } else if (AppState.get().isTextFormat()) {
-                    if (!TempHolder.isSeaching) {
+                    if (!TempHolder.isSearching.get()) {
                         selectText(event.getX(), event.getY(), event.getX(), event.getY());
                         if (!TxtUtils.isFooterNote(AppState.get().selectedText)) {
                             PageImageState.get().cleanSelectedWords();

--- a/EBookDroid/src/com/foobnix/sys/AdvGuestureDetector.java
+++ b/EBookDroid/src/com/foobnix/sys/AdvGuestureDetector.java
@@ -170,7 +170,7 @@ public class AdvGuestureDetector extends SimpleOnGestureListener implements IMul
             }
 
             if (isTextFormat) {
-                if (!TempHolder.isSeaching) {
+                if (!TempHolder.isSearching.get()) {
                     String text = avc.processLongTap(true, e, e, false);
                     if (TxtUtils.isFooterNote(text)) {
                         AppState.get().selectedText = text;

--- a/EBookDroid/src/com/foobnix/sys/TempHolder.java
+++ b/EBookDroid/src/com/foobnix/sys/TempHolder.java
@@ -1,5 +1,6 @@
 package com.foobnix.sys;
 
+import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.locks.ReentrantLock;
 
 import com.foobnix.pdf.info.wrapper.UITab;
@@ -15,7 +16,7 @@ public class TempHolder {
 
     public static int listHash = 0;
 
-    public static volatile boolean isSeaching = false;
+    public static volatile AtomicBoolean isSearching = new AtomicBoolean(false);
     public static volatile boolean isConverting = false;
     public static volatile boolean isRecordTTS = false;
 

--- a/EBookDroid/src/org/ebookdroid/core/DecodeServiceBase.java
+++ b/EBookDroid/src/org/ebookdroid/core/DecodeServiceBase.java
@@ -209,11 +209,13 @@ public class DecodeServiceBase implements DecodeService {
         Thread t = new Thread() {
             @Override
             public void run() {
+                final AtomicBoolean isSearchingLocal = TempHolder.isSearching;
                 PageSearcher pageSearcher= new PageSearcher();
                 pageSearcher.setTextForSearch(text);
                 pageSearcher.setListener(new PageSearcher.OnWordSearched() {
                     @Override
                     public void onSearch(TextWord word, Object data) {
+                        if (!isSearchingLocal.get()) return;
                         if (!(data instanceof Page))return;
                         Page page = (Page) data;
                         if (page.selectedText==null||page.selectedText.size()<=0){
@@ -226,7 +228,7 @@ public class DecodeServiceBase implements DecodeService {
                 });
                 for (Page page : pages) {
 
-                    if (!TempHolder.isSeaching) {
+                    if (!isSearchingLocal.get()) {
                         response.onResultRecive(Integer.MAX_VALUE);
                         finish.run();
                         return;
@@ -237,7 +239,7 @@ public class DecodeServiceBase implements DecodeService {
                     }
 
                     if (isRecycled.get()) {
-                        TempHolder.isSeaching = false;
+                        isSearchingLocal.set(false);
                         return;
                     }
                     if (page.texts == null) {
@@ -265,7 +267,7 @@ public class DecodeServiceBase implements DecodeService {
                 }
                 response.onResultRecive(-1);
                 finish.run();
-                TempHolder.isSeaching = false;
+                isSearchingLocal.set(false);
             };
 
         };

--- a/EBookDroid/src/org/ebookdroid/ui/viewer/VerticalViewActivity.java
+++ b/EBookDroid/src/org/ebookdroid/ui/viewer/VerticalViewActivity.java
@@ -250,7 +250,7 @@ public class VerticalViewActivity extends AbstractActionActivity<VerticalViewAct
         needToRestore = AppState.get().isAutoScroll;
         AppState.get().isAutoScroll = false;
         AppState.get().save(this);
-        TempHolder.isSeaching = false;
+        TempHolder.isSearching.set(false);
         if (handler != null) {
             handler.postDelayed(closeRunnable, AppState.APP_CLOSE_AUTOMATIC);
         }


### PR DESCRIPTION
### Search cancellation
Now user have unobvious behavior of search. 
For example :

* If search in process now, then user **can't start new search** by _"search button"_ (loupe icon).
* if search in process now, and user click _"clear query button"_ (X icon), then **text not cleared**, and list of items not clean too.

This commit fix unobvious behavior.

|before|after|
|-------|-----|
|<img src="https://user-images.githubusercontent.com/1471609/46190938-c5848900-c31f-11e8-91f0-35e0a7592fc3.gif" width=300 />|<img src="https://user-images.githubusercontent.com/1471609/46190952-d92fef80-c31f-11e8-8fb2-845da5ed2587.gif" width=300 />|
