### PR TITLE
Fix initialize values in TTS dialog.

### DIFF
--- a/EBookDroid/src/com/foobnix/pdf/info/view/DragingDialogs.java
+++ b/EBookDroid/src/com/foobnix/pdf/info/view/DragingDialogs.java
@@ -635,7 +635,7 @@ public class DragingDialogs {
                 });
 
                 final CustomSeek seekBarSpeed = (CustomSeek) view.findViewById(R.id.seekBarSpeed);
-                seekBarSpeed.init(0, 600, (int) AppState.get().ttsSpeed * 100);
+                seekBarSpeed.init(0, 600, (int) (AppState.get().ttsSpeed * 100));
                 seekBarSpeed.setStep(10);
                 seekBarSpeed.setOnSeekChanged(new IntegerResponse() {
 
@@ -666,7 +666,7 @@ public class DragingDialogs {
                 TxtUtils.setLinkTextColor(seekBarSpeed.getTitleText());
 
                 final CustomSeek seekBarPitch = (CustomSeek) view.findViewById(R.id.seekBarPitch);
-                seekBarPitch.init(0, 200, (int) AppState.get().ttsPitch * 100);
+                seekBarPitch.init(0, 200, (int) (AppState.get().ttsPitch * 100));
                 seekBarPitch.setOnSeekChanged(new IntegerResponse() {
 
                     @Override


### PR DESCRIPTION
Wrong init values is seted on open "textToSpeachDialog"  (wrong round of float).
Steps for reproduce:
* set TTS speed = 120
* reopen TTS dialog
* TTS speed is 100 <- this is wrong



![ezgif com-video-to-gif 9](https://user-images.githubusercontent.com/1471609/46531921-2e907180-c8c9-11e8-8d61-35e31cbafb04.gif)

