### PR TITLE
TTSService "isActivated" field fixed.

### DIFF
--- a/EBookDroid/src/com/foobnix/tts/TTSService.java
+++ b/EBookDroid/src/com/foobnix/tts/TTSService.java
@@ -361,7 +361,6 @@ public class TTSService extends Service {
             }
 
             mMediaSessionCompat.setActive(true);
-            isActivated = true;
             int pageNumber = intent.getIntExtra(EXTRA_INT, -1);
             AppState.get().lastBookPath = intent.getStringExtra(EXTRA_PATH);
             String anchor = intent.getStringExtra(EXTRA_ANCHOR);
@@ -411,6 +410,7 @@ public class TTSService extends Service {
     @TargetApi(Build.VERSION_CODES.ICE_CREAM_SANDWICH_MR1)
     private void playPage(String preText, int pageNumber, String anchor) {
         if (pageNumber != -1) {
+            isActivated = true;
             EventBus.getDefault().post(new MessagePageNumber(pageNumber));
             AppState.get().lastBookPage = pageNumber;
             CodecDocument dc = getDC();


### PR DESCRIPTION
If I start `TTSService` using `TTS_PLAY` or `TTS_PLAY_PAUSE` or `TTS_NEXT` actions, then the Media buttons on the Bluetooth headphones do not work.
Because` TTSService.isActivated` - is enabled only if I start `TTSService` by `ACTION_PLAY_CURRENT_PAGE` action.
