### PR TITLE
Fix of save current page

### DIFF
--- a/EBookDroid/src/com/foobnix/pdf/info/wrapper/DocumentController.java
+++ b/EBookDroid/src/com/foobnix/pdf/info/wrapper/DocumentController.java
@@ -272,6 +272,8 @@ public abstract class DocumentController {
 
     public void onResume() {
         readTimeStart = System.currentTimeMillis();
+        BookSettings bs = SettingsManager.getBookSettings(getCurrentBook().getPath());
+        onGoToPage(bs.getCurrentPage().viewIndex + 1);
     }
 
     public Bitmap getBookImage() {


### PR DESCRIPTION
If i listen TTS for a long time, then current page not save.
That's happens because activity goes to doze mode.

[![](http://img.youtube.com/vi/e21KR-cA_Cc/0.jpg)](http://www.youtube.com/watch?v=e21KR-cA_Cc "video")

Steps for reproduce:
1) Start TTS ( I start it on 16 page)
2) Lock the screen
3) Turn off charge and listen TTS for a long time ( or turn on Doze Mode by ADB )
4) Stop TTS  ( I stop it on 38 page)
5) Open App. Current page = 16    ( but must be 38 )


P.S. Added page restore on activity resume.