### PR TITLE
Don't download application/x-cbz files as .x-cbz from OPDS catalogs

### DIFF
--- a/app/src/main/java/com/foobnix/opds/Link.java
+++ b/app/src/main/java/com/foobnix/opds/Link.java
@@ -128,6 +128,10 @@ public class Link {
         }
         String name = TxtUtils.fixFileName(parentTitle);
         String ext = getDownloadDisplayFormat();
+        
+        // Workaround for application/x-cbz and application/x-cbr
+        ext = ext.replace("x-cbz","cbz").replace("x-cbr","cbr");
+        
         if (ext != null) {
             return name + "." + ext;
         }


### PR DESCRIPTION
When downloading files from OPDS catalogs with application/x-cbz or application/x-cbr types, Librera downloads them as `.x-cbz` files, and subsequently fails to read them.  

This PR fixes the issue with a dumb check for those two types.