### PR TITLE
add config option for profile directory

### DIFF
--- a/app/src/main/java/com/foobnix/model/AppProfile.java
+++ b/app/src/main/java/com/foobnix/model/AppProfile.java
@@ -47,6 +47,7 @@ public class AppProfile {
     public static final String PROFILE_PREFIX = "profile.";
     public static final String DEVICE_PREFIX = "device.";
     public static final File DOWNLOADS_DIR = Environment.getExternalStoragePublicDirectory(Environment.DIRECTORY_DOWNLOADS);
+    public static final File DEFAULT_SYNC_FOLDER_ROOT = new File(Environment.getExternalStorageDirectory(), "Librera");
     public static final String DEVICE_MODEL = DEVICE_PREFIX + Build.MODEL.replace(" ", "_");
     public static final String APP_STATE_JSON = "app-State.json";
     public static final String APP_CSS_JSON = "app-CSS.json";
@@ -58,9 +59,9 @@ public class AppProfile {
     public static final String APP_TAGS_JSON = "app-Tags.json";
 
 
-    public static File SYNC_FOLDER_ROOT = new File(Environment.getExternalStorageDirectory(), "Librera");
-    public static File SYNC_FOLDER_BOOKS = new File(SYNC_FOLDER_ROOT, "Books");
-    public static File SYNC_FOLDER_DICT = new File(SYNC_FOLDER_ROOT, "dict");
+    public static File SYNC_FOLDER_ROOT;
+    public static File SYNC_FOLDER_BOOKS;
+    public static File SYNC_FOLDER_DICT;
     public static File SYNC_FOLDER_PROFILE;
     public static File SYNC_FOLDER_DEVICE_PROFILE;
     public static File syncRecent;
@@ -96,6 +97,9 @@ public class AppProfile {
         AppDB.get().open(c, profile);
         LOG.d("AppProfile init", profile);
 
+        SYNC_FOLDER_ROOT = new File(sp.getString("syncFolderRoot", DEFAULT_SYNC_FOLDER_ROOT.toString()));
+        SYNC_FOLDER_BOOKS = new File(SYNC_FOLDER_ROOT, "Books");
+        SYNC_FOLDER_DICT = new File(SYNC_FOLDER_ROOT, "dict");
 
         SYNC_FOLDER_PROFILE = new File(SYNC_FOLDER_ROOT, PROFILE_PREFIX + getCurrent(c));
         SYNC_FOLDER_DEVICE_PROFILE = new File(SYNC_FOLDER_PROFILE, DEVICE_MODEL);

--- a/app/src/main/java/com/foobnix/ui2/fragment/PrefFragment2.java
+++ b/app/src/main/java/com/foobnix/ui2/fragment/PrefFragment2.java
@@ -3,9 +3,11 @@ package com.foobnix.ui2.fragment;
 import android.annotation.SuppressLint;
 import android.app.AlertDialog;
 import android.app.Dialog;
+import android.content.Context;
 import android.content.DialogInterface;
 import android.content.DialogInterface.OnDismissListener;
 import android.content.Intent;
+import android.content.SharedPreferences;
 import android.content.pm.PackageInfo;
 import android.content.pm.PackageManager.NameNotFoundException;
 import android.graphics.Color;
@@ -1550,6 +1552,27 @@ public class PrefFragment2 extends UIFragment {
                         getActivity()));
 
         // folders
+
+        final TextView rootFolder = (TextView) inflate.findViewById(R.id.rootFolder);
+        SharedPreferences sp = getContext().getSharedPreferences("AppProfile", Context.MODE_PRIVATE);
+        TxtUtils.underline(rootFolder, TxtUtils.lastTwoPath(sp.getString("syncFolderRoot", AppProfile.DEFAULT_SYNC_FOLDER_ROOT.toString())));
+        rootFolder.setOnClickListener(new
+
+                                             OnClickListener() {
+
+                                                 @Override
+                                                 public void onClick(View v) {
+                                                     ChooserDialogFragment.chooseFolder(getActivity(), sp.getString("syncFolderRoot", AppProfile.DEFAULT_SYNC_FOLDER_ROOT.toString())).setOnSelectListener(new ResultResponse2<String, Dialog>() {
+                                                         @Override
+                                                         public boolean onResultRecive(String nPath, Dialog dialog) {
+                                                             sp.edit().putString("syncFolderRoot", nPath).commit();
+                                                             TxtUtils.underline(rootFolder, TxtUtils.lastTwoPath(nPath));
+                                                             dialog.dismiss();
+                                                             return false;
+                                                         }
+                                                     });
+                                                 }
+                                             });
 
         final TextView fontFolder = (TextView) inflate.findViewById(R.id.fontFolder);
         TxtUtils.underline(fontFolder, TxtUtils.lastTwoPath(BookCSS.get().fontFolder));

--- a/app/src/main/res/layout/preferences.xml
+++ b/app/src/main/res/layout/preferences.xml
@@ -1303,6 +1303,27 @@
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
                 android:width="135dip"
+                android:text="@string/folder_for_sync_root" />
+
+            <TextView
+                android:id="@+id/rootFolder"
+                style="@style/textLink"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:ellipsize="start"
+                android:text="[]" />
+        </LinearLayout>
+
+        <LinearLayout
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:gravity="center_vertical"
+            android:orientation="horizontal">
+
+            <TextView
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:width="135dip"
                 android:text="@string/folder_with_fonts" />
 
             <TextView

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -198,6 +198,7 @@
    <string name="port">Port</string>
    <string name="user">User</string>
    <string name="other_settings">Additional Settings</string>
+   <string name="folder_for_sync_root">Profile Root</string>
    <string name="folder_for_downloaded_books">Downloads</string>
    <string name="display_large_book_covers_in_the_catalog">Large book covers in catalogs</string>
    <string name="add_catalog">New Catalog</string>


### PR DESCRIPTION
Allow the user to configure `SYNC_FOLDER_ROOT`. This is useful when one
wants to integrate Librera into an existing synchronization setup.
It can also be used to avoid polluting `$HOME` (i.e. `/storage/emulated/0`).

My knowledge of java & android is rusty at best and I'm not yet familiar with
this project's structure. So please just tell me if I've done something plain wrong
or unidiomatic.

The name of the new option is not yet translated. Should I just include
dictionary translations or leave that to someone that actually knows the
other languages?