### PR TITLE
Removed local pathes from build scripts

### DIFF
--- a/Builder/link_to_mupdf_1.11.sh
+++ b/Builder/link_to_mupdf_1.11.sh
@@ -1,6 +1,11 @@
 #!/usr/bin/env bash
 #. ~/.profile
 
+# get the location of this script, we will checkout mupdf into the same directory
+BUILD_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
+
+cd $BUILD_DIR
+
 echo "MUPDF : 1.11"
 echo "================== "
 
@@ -11,11 +16,11 @@ make
 echo "================== "
 cd ..
 
-MUPDF_ROOT=/home/ivan-dev/git/LibreraReader/Builder/mupdf-1.11
+MUPDF_ROOT=${BUILD_DIR}/mupdf-1.11
 
 MUPDF_JAVA=$MUPDF_ROOT/platform/java
 
-LIBS=/home/ivan-dev/git/LibreraReader/app/src/main/jniLibs
+LIBS=${BUILD_DIR}/../app/src/main/jniLibs
 
 rm -rf  $MUPDF_JAVA/jni
 cp -rRp jni $MUPDF_JAVA/jni

--- a/Builder/link_to_mupdf_1.16.1.sh
+++ b/Builder/link_to_mupdf_1.16.1.sh
@@ -1,12 +1,17 @@
 #!/usr/bin/env bash
 #. ~/.profile
 
+# get the location of this script, we will checkout mupdf into the same directory
+BUILD_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
+
+cd $BUILD_DIR
+
 VERSION=1.16.1
 
-MUPDF_ROOT=/home/ivan-dev/git/LibreraReader/Builder/mupdf-$VERSION
+MUPDF_ROOT=${BUILD_DIR}/mupdf-$VERSION
 MUPDF_JAVA=$MUPDF_ROOT/platform/java
 
-LIBS=/home/ivan-dev/git/LibreraReader/app/src/main/jniLibs
+LIBS=${BUILD_DIR}/../app/src/main/jniLibs
 
 SRC=jni/~mupdf-$VERSION
 DEST=$MUPDF_ROOT/source/

--- a/Builder/link_to_mupdf_master.sh
+++ b/Builder/link_to_mupdf_master.sh
@@ -1,6 +1,13 @@
 #!/usr/bin/env bash
 #. ~/.profile
 
+# get the location of this script, we will checkout mupdf into the same directory
+BUILD_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
+
+cd $BUILD_DIR
+
+echo "MUPDF : master"
+echo "================== "
 git clone --recursive git://git.ghostscript.com/mupdf.git mupdf-master
 cd mupdf-master
 git reset --hard origin/master
@@ -19,11 +26,11 @@ make generate
 
 cd ..
 
-MUPDF_ROOT=/home/ivan-dev/git/LibreraReader/Builder/mupdf-master
+MUPDF_ROOT=${BUILD_DIR}/mupdf-master
 
 MUPDF_JAVA=$MUPDF_ROOT/platform/java
 
-LIBS=/home/ivan-dev/git/LibreraReader/app/src/main/jniLibs
+LIBS=${BUILD_DIR}/../app/src/main/jniLibs
 
 rm -rf  $MUPDF_JAVA/jni
 cp -rRp jni-master $MUPDF_JAVA/jni


### PR DESCRIPTION
Now the scripts do no more need to be changed depending on location of
the repo in the local file system.

The script to build the master does not work, but did also not before (there is no jni-master in Builder directory).