### PR TITLE
Add support for playlist resume

### DIFF
--- a/app/src/main/java/com/foobnix/pdf/info/Playlist.java
+++ b/app/src/main/java/com/foobnix/pdf/info/Playlist.java
@@ -1,0 +1,113 @@
+package com.foobnix.pdf.info;
+
+import com.foobnix.android.utils.LOG;
+import com.foobnix.android.utils.TxtUtils;
+import com.foobnix.model.MyPath;
+
+import java.io.BufferedReader;
+import java.io.BufferedWriter;
+import java.io.File;
+import java.io.FileReader;
+import java.io.FileWriter;
+import java.io.IOException;
+import java.io.PrintWriter;
+import java.util.ArrayList;
+import java.util.List;
+
+public class Playlist {
+    private final static String CURRENT_FILE_PREFIX = ">";
+    private final String name;
+    private List<String> paths;
+    private int currentPathIndex;
+
+    public Playlist(String name) {
+        this.name = name;
+        this.paths = new ArrayList<>();
+        this.currentPathIndex = 0;
+    }
+
+    public List<String> getPaths() {
+        return paths;
+    }
+
+    public void setPaths(List<String> paths) {
+        this.paths = paths;
+    }
+
+    public void setCurrentPath(String currentPath) {
+        this.currentPathIndex = this.paths.indexOf(currentPath);
+    }
+
+    public boolean hasCurrentItem() {
+        return this.currentPathIndex != 0;
+    }
+
+    public List<String> getItems() {
+        if (this.paths.size() > 0) {
+            return this.paths;
+        }
+        List<String> res = new ArrayList<>();
+        try {
+            if (TxtUtils.isEmpty(this.name)) {
+                return res;
+            }
+
+            File child = Playlists.getFile(this.name);
+
+            BufferedReader reader = new BufferedReader(new FileReader(child));
+
+            String line;
+            int currentPathIndex = 0;
+
+            while ((line = reader.readLine()) != null) {
+                if (TxtUtils.isNotEmpty(line)) {
+                    if (line.startsWith(CURRENT_FILE_PREFIX)) {
+                        line = line.replace(CURRENT_FILE_PREFIX, "");
+                        this.currentPathIndex = currentPathIndex;
+                    }
+                    line = MyPath.toAbsolute(line);
+                    res.add(line.replace(Playlists.L_PLAYLIST, ""));
+                    currentPathIndex++;
+                }
+            }
+            reader.close();
+        } catch (Exception e) {
+            LOG.e(e);
+        }
+        this.setPaths(res);
+        return res;
+    }
+
+    public void updateCurrentFile(String currentFile) {
+        this.setCurrentPath(currentFile);
+        this.update(this.paths);
+    }
+
+    public void update(List<String> items) {
+        File child = Playlists.getFile(this.name);
+        LOG.d("Playlists", "updatePlaylist", child);
+
+        String currentItem = items.get(this.currentPathIndex);
+        try {
+            PrintWriter out = new PrintWriter(new BufferedWriter(new FileWriter(child)));
+            for (String path : items) {
+                out.println((path.equals(currentItem) ? ">" : "") + MyPath.toRelative(path));
+            }
+            out.close();
+            this.setPaths(items);
+        } catch (IOException e) {
+            LOG.e(e);
+        }
+
+    }
+
+    public String getFirstItem() {
+        try {
+            return getItems().get(this.currentPathIndex); // invoked when you clicked play
+        } catch (Exception e) {
+            LOG.e(e);
+            return this.name;
+        }
+    }
+
+}

--- a/app/src/main/java/com/foobnix/pdf/info/Playlist.java
+++ b/app/src/main/java/com/foobnix/pdf/info/Playlist.java
@@ -103,7 +103,7 @@ public class Playlist {
 
     public String getFirstItem() {
         try {
-            return getItems().get(this.currentPathIndex); // invoked when you clicked play
+            return getItems().get(this.currentPathIndex);
         } catch (Exception e) {
             LOG.e(e);
             return this.name;

--- a/app/src/main/java/com/foobnix/pdf/info/Playlist.java
+++ b/app/src/main/java/com/foobnix/pdf/info/Playlist.java
@@ -71,10 +71,10 @@ public class Playlist {
                 }
             }
             reader.close();
+            this.setPaths(res);
         } catch (Exception e) {
             LOG.e(e);
         }
-        this.setPaths(res);
         return res;
     }
 

--- a/app/src/main/java/com/foobnix/pdf/info/Playlists.java
+++ b/app/src/main/java/com/foobnix/pdf/info/Playlists.java
@@ -30,7 +30,8 @@ public class Playlists {
     public static void createPlayList(String playlistName) {
         LOG.d("Playlists", "createPlayList", playlistName);
 
-        if (playlists.containsKey(playlistName) || TxtUtils.isEmpty(playlistName)) {
+        String fileName = playlistName + L_PLAYLIST;
+        if (playlists.containsKey(fileName) || TxtUtils.isEmpty(playlistName)) {
             return;
         }
 

--- a/app/src/main/java/com/foobnix/pdf/info/view/DialogsPlaylist.java
+++ b/app/src/main/java/com/foobnix/pdf/info/view/DialogsPlaylist.java
@@ -252,7 +252,8 @@ public class DialogsPlaylist {
             }
 
             @Override
-            public void onItemClick(String result) {
+            public void onItemClick(String result) { // invoked from playlist dialog
+                Playlists.updatePlaylistAndCurrentItem(file, result);
                 Playlists.updatePlaylist(file, res);
                 EventBus.getDefault().post(new UpdateAllFragments());
 
@@ -296,7 +297,8 @@ public class DialogsPlaylist {
             }
         });
         if (res.size() > 0 && refresh == null) {
-            builder.setPositiveButton(R.string.play, new AlertDialog.OnClickListener() {
+            int displayText = Playlists.getPlaylist(file).hasCurrentItem() ? R.string.resume_playlist : R.string.play;
+            builder.setPositiveButton(displayText, new AlertDialog.OnClickListener() {
 
                 @Override
                 public void onClick(DialogInterface dialog, int which) {
@@ -336,17 +338,17 @@ public class DialogsPlaylist {
         playlistRecycleView.setVisibility(View.GONE);
         playListParent.setVisibility(View.GONE);
 
-        final String palylistPath = a.getIntent().getStringExtra(DocumentController.EXTRA_PLAYLIST);
+        final String playlistPath = a.getIntent().getStringExtra(DocumentController.EXTRA_PLAYLIST);
 
-        if (TxtUtils.isNotEmpty(palylistPath)) {
-            playListName.setText(Playlists.formatPlaylistName(palylistPath));
+        if (TxtUtils.isNotEmpty(playlistPath)) {
+            playListName.setText(Playlists.formatPlaylistName(playlistPath));
             playListName.setVisibility(View.VISIBLE);
             playListParent.setVisibility(View.VISIBLE);
             playListNameEdit.setVisibility(View.VISIBLE);
             playlistRecycleView.setVisibility(View.VISIBLE);
         }
 
-        final List<String> res = Playlists.getPlaylistItems(palylistPath);
+        final List<String> res = Playlists.getPlaylistItems(playlistPath);
 
         final PlaylistAdapter adapter = new PlaylistAdapter(a, res, new OnStartDragListener() {
 
@@ -359,15 +361,16 @@ public class DialogsPlaylist {
             }
 
             @Override
-            public void onItemClick(final String s) {
-                LOG.d("onItemClick", s);
-                if (dc != null && dc.getCurrentBook() != null && !dc.getCurrentBook().getPath().equals(s)) {
+            public void onItemClick(final String itemPath) {
+                LOG.d("onItemClick", itemPath);
+                if (dc != null && dc.getCurrentBook() != null && !dc.getCurrentBook().getPath().equals(itemPath)) {
 
                     dc.onCloseActivityFinal(new Runnable() {
 
                         @Override
                         public void run() {
-                            ExtUtils.showDocumentWithoutDialog(a, new File(s), palylistPath);
+                            Playlists.updatePlaylistAndCurrentItem(playlistPath, itemPath);
+                            ExtUtils.showDocumentWithoutDialog(a, new File(itemPath), playlistPath);
                         }
                     });
                 }
@@ -390,11 +393,11 @@ public class DialogsPlaylist {
 
             @Override
             public void onClick(View v) {
-                showPlayList(a, palylistPath, new Runnable() {
+                showPlayList(a, playlistPath, new Runnable() {
                     @Override
                     public void run() {
                         adapter.getItems().clear();
-                        adapter.getItems().addAll(Playlists.getPlaylistItems(palylistPath));
+                        adapter.getItems().addAll(Playlists.getPlaylistItems(playlistPath));
                         adapter.notifyDataSetChanged();
 
                     }

--- a/app/src/main/java/com/foobnix/pdf/info/view/DialogsPlaylist.java
+++ b/app/src/main/java/com/foobnix/pdf/info/view/DialogsPlaylist.java
@@ -298,6 +298,17 @@ public class DialogsPlaylist {
         });
         if (res.size() > 0 && refresh == null) {
             int displayText = Playlists.getPlaylist(file).hasCurrentItem() ? R.string.resume_playlist : R.string.play;
+            if (Playlists.getPlaylist(file).hasCurrentItem()) {
+                builder.setNeutralButton(R.string.resume_playlist, (dialogInterface, i) -> {
+                    LOG.d("play-click", file);
+                    update.run();
+
+                    FileMeta f = new FileMeta(Playlists.getFile(file).getPath());
+                    LOG.d("play-click meta", f.getPath());
+
+                    ExtUtils.openFile((Activity) a, f);
+                });
+            }
             builder.setPositiveButton(displayText, new AlertDialog.OnClickListener() {
 
                 @Override

--- a/app/src/main/java/com/foobnix/pdf/info/view/DialogsPlaylist.java
+++ b/app/src/main/java/com/foobnix/pdf/info/view/DialogsPlaylist.java
@@ -47,6 +47,7 @@ import com.jmedeisis.draglinearlayout.DragLinearLayout;
 import org.greenrobot.eventbus.EventBus;
 
 import java.io.File;
+import java.util.ArrayList;
 import java.util.List;
 
 public class DialogsPlaylist {
@@ -297,7 +298,6 @@ public class DialogsPlaylist {
             }
         });
         if (res.size() > 0 && refresh == null) {
-            int displayText = Playlists.getPlaylist(file).hasCurrentItem() ? R.string.resume_playlist : R.string.play;
             if (Playlists.getPlaylist(file).hasCurrentItem()) {
                 builder.setNeutralButton(R.string.resume_playlist, (dialogInterface, i) -> {
                     LOG.d("play-click", file);
@@ -309,7 +309,7 @@ public class DialogsPlaylist {
                     ExtUtils.openFile((Activity) a, f);
                 });
             }
-            builder.setPositiveButton(displayText, new AlertDialog.OnClickListener() {
+            builder.setPositiveButton(R.string.play, new AlertDialog.OnClickListener() {
 
                 @Override
                 public void onClick(DialogInterface dialog, int which) {
@@ -359,7 +359,7 @@ public class DialogsPlaylist {
             playlistRecycleView.setVisibility(View.VISIBLE);
         }
 
-        final List<String> res = Playlists.getPlaylistItems(playlistPath);
+        final List<String> res = playlistPath == null ? new ArrayList<>() : Playlists.getPlaylistItems(playlistPath);
 
         final PlaylistAdapter adapter = new PlaylistAdapter(a, res, new OnStartDragListener() {
 

--- a/app/src/main/java/com/foobnix/pdf/info/view/DialogsPlaylist.java
+++ b/app/src/main/java/com/foobnix/pdf/info/view/DialogsPlaylist.java
@@ -252,7 +252,7 @@ public class DialogsPlaylist {
             }
 
             @Override
-            public void onItemClick(String result) { // invoked from playlist dialog
+            public void onItemClick(String result) {
                 Playlists.updatePlaylistAndCurrentItem(file, result);
                 Playlists.updatePlaylist(file, res);
                 EventBus.getDefault().post(new UpdateAllFragments());

--- a/app/src/main/java/com/foobnix/pdf/info/view/drag/PlaylistAdapter.java
+++ b/app/src/main/java/com/foobnix/pdf/info/view/drag/PlaylistAdapter.java
@@ -63,7 +63,7 @@ public class PlaylistAdapter extends RecyclerView.Adapter<PlaylistAdapter.ItemVi
 
             @Override
             public void onClick(View v) {
-                mDragStartListener.onItemClick(item); // invoked on click from inside reader
+                mDragStartListener.onItemClick(item);
             }
         });
 

--- a/app/src/main/java/com/foobnix/pdf/info/view/drag/PlaylistAdapter.java
+++ b/app/src/main/java/com/foobnix/pdf/info/view/drag/PlaylistAdapter.java
@@ -63,7 +63,7 @@ public class PlaylistAdapter extends RecyclerView.Adapter<PlaylistAdapter.ItemVi
 
             @Override
             public void onClick(View v) {
-                mDragStartListener.onItemClick(item);
+                mDragStartListener.onItemClick(item); // invoked on click from inside reader
             }
         });
 

--- a/app/src/main/java/com/foobnix/ui2/adapter/FileMetaAdapter.java
+++ b/app/src/main/java/com/foobnix/ui2/adapter/FileMetaAdapter.java
@@ -274,6 +274,7 @@ public class FileMetaAdapter extends AppRecycleAdapter<FileMeta, RecyclerView.Vi
             holder.parent.setContentDescription(holder.getString(R.string.folder) + " " + fileMeta.getTitle());
 
             holder.play.setVisibility(View.GONE);
+            holder.resume.setVisibility(View.GONE);
             holder.title.setText(fileMeta.getPathTxt());
             holder.path.setText(fileMeta.getPath());
 
@@ -333,14 +334,17 @@ public class FileMetaAdapter extends AppRecycleAdapter<FileMeta, RecyclerView.Vi
                 }
             }
 
+            TextView viewAction = holder.play;
             if (fileMeta.getCusType() == DISPLAY_TYPE_PLAYLIST) {
                 holder.image.setImageResource(R.drawable.glyphicons_160_playlist);
                 holder.starIcon.setVisibility(View.GONE);
                 holder.path.setVisibility(View.GONE);
-                holder.play.setVisibility(View.VISIBLE);
+                viewAction = !Playlists.getPlaylist(fileMeta.getPath()).hasCurrentItem()
+                        ? holder.play : holder.resume;
+                viewAction.setVisibility(View.VISIBLE);
                 holder.count.setVisibility(View.VISIBLE);
 
-                holder.play.setText(holder.play.getText().toString().toUpperCase(Locale.US));
+                viewAction.setText(viewAction.getText().toString().toUpperCase(Locale.US));
                 int i1 = fileMeta.getPathTxt().indexOf("(");
                 int i2 = fileMeta.getPathTxt().indexOf(")");
 
@@ -352,9 +356,9 @@ public class FileMetaAdapter extends AppRecycleAdapter<FileMeta, RecyclerView.Vi
                     holder.count.setVisibility(View.GONE);
                 }
 
-                TxtUtils.underlineTextView(holder.play);
+                TxtUtils.underlineTextView(viewAction);
 
-                holder.play.setOnClickListener(new OnClickListener() {
+                viewAction.setOnClickListener(new OnClickListener() {
 
                     @Override
                     public void onClick(View v) {
@@ -362,7 +366,7 @@ public class FileMetaAdapter extends AppRecycleAdapter<FileMeta, RecyclerView.Vi
                     }
                 });
                 if (TEMP_VALUE_STAR_GRID_ITEM == tempValue || new File(fileMeta.getPath()).length() == 0) {
-                    holder.play.setVisibility(View.GONE);
+                    viewAction.setVisibility(View.GONE);
                 }
             }
 
@@ -370,7 +374,7 @@ public class FileMetaAdapter extends AppRecycleAdapter<FileMeta, RecyclerView.Vi
                 holder.parent.setBackgroundColor(Color.BLACK);
             }
 
-            TxtUtils.setInkTextView(holder.title, holder.path, holder.play, holder.count);
+            TxtUtils.setInkTextView(holder.title, holder.path, viewAction, holder.count);
 
         } else if (holderAll instanceof StarsLayoutViewHolder) {
             final StarsLayoutViewHolder holder = (StarsLayoutViewHolder) holderAll;
@@ -1029,7 +1033,7 @@ public class FileMetaAdapter extends AppRecycleAdapter<FileMeta, RecyclerView.Vi
     }
 
     public class DirectoryViewHolder extends ContextViewHolder {
-        public TextView title, path, play, count;
+        public TextView title, path, play, resume, count;
         public ImageView image, starIcon, imageCloud;
         public View parent;
 
@@ -1038,6 +1042,7 @@ public class FileMetaAdapter extends AppRecycleAdapter<FileMeta, RecyclerView.Vi
             title = (TextView) view.findViewById(R.id.text1);
             count = (TextView) view.findViewById(R.id.count);
             play = (TextView) view.findViewById(R.id.play);
+            resume = (TextView) view.findViewById(R.id.resume);
             path = (TextView) view.findViewById(R.id.text2);
             image = (ImageView) view.findViewById(R.id.image1);
             starIcon = (ImageView) view.findViewById(R.id.starIcon);

--- a/app/src/main/java/com/foobnix/ui2/adapter/FileMetaAdapter.java
+++ b/app/src/main/java/com/foobnix/ui2/adapter/FileMetaAdapter.java
@@ -334,17 +334,27 @@ public class FileMetaAdapter extends AppRecycleAdapter<FileMeta, RecyclerView.Vi
                 }
             }
 
-            TextView viewAction = holder.play;
             if (fileMeta.getCusType() == DISPLAY_TYPE_PLAYLIST) {
                 holder.image.setImageResource(R.drawable.glyphicons_160_playlist);
                 holder.starIcon.setVisibility(View.GONE);
                 holder.path.setVisibility(View.GONE);
-                viewAction = !Playlists.getPlaylist(fileMeta.getPath()).hasCurrentItem()
-                        ? holder.play : holder.resume;
-                viewAction.setVisibility(View.VISIBLE);
+                holder.play.setVisibility(View.VISIBLE);
                 holder.count.setVisibility(View.VISIBLE);
+                if (Playlists.getPlaylist(fileMeta.getPath()).hasCurrentItem()) {
+                    holder.resume.setVisibility(View.VISIBLE);
+                    holder.resume.setText(holder.resume.getText().toString().toUpperCase(Locale.US));
+                    TxtUtils.underlineTextView(holder.resume);
+                    holder.resume.setOnClickListener(new OnClickListener() {
 
-                viewAction.setText(viewAction.getText().toString().toUpperCase(Locale.US));
+                        @Override
+                        public void onClick(View v) {
+                            onItemLongClickListener.onResultRecive(fileMeta);
+                        }
+                    });
+                }
+
+
+                holder.play.setText(holder.play.getText().toString().toUpperCase(Locale.US));
                 int i1 = fileMeta.getPathTxt().indexOf("(");
                 int i2 = fileMeta.getPathTxt().indexOf(")");
 
@@ -356,9 +366,9 @@ public class FileMetaAdapter extends AppRecycleAdapter<FileMeta, RecyclerView.Vi
                     holder.count.setVisibility(View.GONE);
                 }
 
-                TxtUtils.underlineTextView(viewAction);
+                TxtUtils.underlineTextView(holder.play);
 
-                viewAction.setOnClickListener(new OnClickListener() {
+                holder.play.setOnClickListener(new OnClickListener() {
 
                     @Override
                     public void onClick(View v) {
@@ -366,7 +376,7 @@ public class FileMetaAdapter extends AppRecycleAdapter<FileMeta, RecyclerView.Vi
                     }
                 });
                 if (TEMP_VALUE_STAR_GRID_ITEM == tempValue || new File(fileMeta.getPath()).length() == 0) {
-                    viewAction.setVisibility(View.GONE);
+                    holder.play.setVisibility(View.GONE);
                 }
             }
 
@@ -374,7 +384,7 @@ public class FileMetaAdapter extends AppRecycleAdapter<FileMeta, RecyclerView.Vi
                 holder.parent.setBackgroundColor(Color.BLACK);
             }
 
-            TxtUtils.setInkTextView(holder.title, holder.path, viewAction, holder.count);
+            TxtUtils.setInkTextView(holder.title, holder.path, holder.play, holder.count);
 
         } else if (holderAll instanceof StarsLayoutViewHolder) {
             final StarsLayoutViewHolder holder = (StarsLayoutViewHolder) holderAll;

--- a/app/src/main/res/layout/browse_dir.xml
+++ b/app/src/main/res/layout/browse_dir.xml
@@ -98,6 +98,14 @@
             android:layout_marginRight="10dip"
             android:textSize="14sp" />
 
+        <TextView
+            android:id="@+id/resume"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:text="@string/resume_playlist"
+            android:layout_marginRight="10dip"
+            android:textSize="14sp" />
+
         <ImageView
             android:id="@+id/starIcon"
             android:layout_width="@dimen/wh_button"

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -632,4 +632,5 @@
    <string name="the_application_needs_storage_permission">The application needs permission to access the storage to find all books</string>
    <string name="always_open_in_2_pages_mode">Open in 2-page mode</string>
    <string name="text_encoding">Text encoding</string>
+   <string name="resume_playlist">Resume</string>
 </resources>


### PR DESCRIPTION
## Story/Why
Hey I recently used a lot this app to read a manga and to be able to efficiently move from chapter to chapter, I ended up generating a playlist (it had 180 chapters).

I really liked it, but the fact that closing the playlist meant for me to remember where I left off was a little disappointing (sarcasm warning: oh noo I had to use my brain :crying_cat_face: ) . So here I am, I coded a bit of Java to try and add that feature! 

## What
But this is incomplete/not ready because I couldn't figure out how to setup everything. Right now my PR adds:
- When you load playlists, we check if they have a "in progress" marker and display a "RESUME" button along side the "PLAY" button.
  - There is a problem with the PLAY/RESUME because I couldn't figure out how to transmit the difference between the two options down to the actual file opening. Right now, I implemented that both PLAY and RESUME do the RESUME action. That's where I'd like your wisdom.
- I extracted the logic of handling a playlist to its class (`Playlist`) and `Playlists` only serves the playlists through a map.
  - We "cache" the content of a playlist: on read we check the cache and serves it if we have data, but we always write the updates to the playlist file. The write could be improved to do as the read.
- I renamed some variables I saw along the way of my changes. This was not consistent and is mostly a side product of me reading through the code.

## Closing
Thanks for sharing this app with the world! Talk with you when you see this!
Cheers

## Gallery

When no progress with playlist (yes lol.playlist)
![SmartSelect_20220204-190959](https://user-images.githubusercontent.com/18617578/152619959-dad4df4b-47a4-460a-a218-e0f486bac27b.jpg)
![SmartSelect_20220204-190938](https://user-images.githubusercontent.com/18617578/152619960-d7268922-a81f-47db-9013-ebb4839dfe23.jpg)

When you have progress
![SmartSelect_20220204-191017](https://user-images.githubusercontent.com/18617578/152619979-d09502d4-6152-4ee9-bd39-e720b53b9fb0.jpg)
![Screenshot_20220204-191212](https://user-images.githubusercontent.com/18617578/152619980-2b01dc51-1526-4c3f-a172-fd5c83bace8b.jpg)


