### PR TITLE
Remove ellipsis when clicking on 'more' in FileInformationDialog

### DIFF
--- a/app/src/main/java/com/foobnix/pdf/info/widget/FileInformationDialog.java
+++ b/app/src/main/java/com/foobnix/pdf/info/widget/FileInformationDialog.java
@@ -214,6 +214,7 @@ public class FileInformationDialog {
             public void onClick(View v) {
                 // AlertDialogs.showOkDialog(a, infoView.getText().toString(), null);
                 infoView.setMaxLines(Integer.MAX_VALUE);
+                infoView.setEllipsize(null);
                 infoView.setTextIsSelectable(true);
                 expand.setVisibility(View.GONE);
             }


### PR DESCRIPTION
This patch fixes the following issue which occurs when clicking on `more` in the file information dialog(notice the added `...`):
![image](https://user-images.githubusercontent.com/18737914/176704499-9a755766-8c22-4ea9-a726-40641a1da9ec.png)
