### PR TITLE
Fix search of 'No series'

### DIFF
--- a/app/src/main/java/com/foobnix/ui2/fragment/SearchFragment2.java
+++ b/app/src/main/java/com/foobnix/ui2/fragment/SearchFragment2.java
@@ -575,10 +575,6 @@ public class SearchFragment2 extends UIFragment<FileMeta> {
     }
 
     private void onMetaInfoClick(SEARCH_IN mode, String result) {
-        if (mode == SEARCH_IN.SERIES) {
-            result = "," + result + ",";
-        }
-
         searchEditText.setText(mode.getDotPrefix() + " " + result);
         AppState.get().libraryMode = prevLibModeFileMeta;
         onGridList();


### PR DESCRIPTION
This patch fixes the `series -> no series` search, I'm unsure why `,` was added at all to the result (it seems to add nothing of value?) so I've removed it and that seems to fix it.

