### PR TITLE
Change exact match character to "

### DIFF
--- a/app/src/main/java/com/foobnix/android/utils/StringDB.java
+++ b/app/src/main/java/com/foobnix/android/utils/StringDB.java
@@ -10,6 +10,7 @@ import java.util.Set;
 
 public class StringDB {
     public static String DIVIDER = ",";
+    public static String EXACTMATCHCHAR = "\"";
 
     public static void add(String db, String text, final StringResult result) {
         if (TxtUtils.isEmpty(text)) {

--- a/app/src/main/java/com/foobnix/ui2/AppDB.java
+++ b/app/src/main/java/com/foobnix/ui2/AppDB.java
@@ -539,11 +539,12 @@ public class AppDB {
 
             }
             LOG.d("searchBy", searchIn, str, "-");
-            if (str.startsWith(SearchFragment2.EMPTY_ID) || str.startsWith(","+SearchFragment2.EMPTY_ID)) {
+            if (str.startsWith(SearchFragment2.EMPTY_ID)) {
                 where = where.whereOr(searchIn.getProperty().like(""), searchIn.getProperty().isNull());
             } else {
                 if (TxtUtils.isNotEmpty(str)) {
                     str = str.replace(" ", "%").replace("*", "%");
+                    str = str.replace(StringDB.EXACTMATCHCHAR, StringDB.DIVIDER);
 
                     String string = "%" + str + "%";
 

--- a/app/src/main/java/com/foobnix/ui2/fragment/SearchFragment2.java
+++ b/app/src/main/java/com/foobnix/ui2/fragment/SearchFragment2.java
@@ -581,8 +581,8 @@ public class SearchFragment2 extends UIFragment<FileMeta> {
     }
 
     private void onMetaInfoClick(SEARCH_IN mode, String result) {
-        if (mode == SEARCH_IN.SERIES) {
-            result = "," + result + ",";
+        if (mode == SEARCH_IN.SERIES && !result.startsWith(EMPTY_ID)) {
+            result = StringDB.EXACTMATCHCHAR + result + StringDB.EXACTMATCHCHAR;
         }
 
         searchEditText.setText(mode.getDotPrefix() + " " + result);


### PR DESCRIPTION
This changes the exact match character from `,` to `"` which makes more sense in my opinion and looks better.

Instead of searching for `@series ,Transformers: Optimus Prime,` you can now use `@series "Transformers: Optimus Prime"`


Thanks to @JaxonWasTaken for the idea