### PR TITLE
inconvenient use of application menu

### DIFF
--- a/app/src/main/java/com/foobnix/ui2/MainTabs2.java
+++ b/app/src/main/java/com/foobnix/ui2/MainTabs2.java
@@ -370,8 +370,13 @@ public class MainTabs2 extends AdsFragmentActivity {
         setContentView(R.layout.main_tabs);
 
 
-        imageMenu = (ImageView) findViewById(R.id.imageMenu1);
-        imageMenuParent = findViewById(R.id.imageParent1);
+        if (AppState.get().tapPositionTop) {
+            imageMenu = (ImageView) findViewById(R.id.imageMenu1);
+            imageMenuParent = findViewById(R.id.imageParent1);
+        } else {
+            imageMenu = (ImageView) findViewById(R.id.imageMenu2);
+            imageMenuParent = findViewById(R.id.imageParent2);
+        }
         imageMenuParent.setBackgroundColor(TintUtil.color);
 
         fab = findViewById(R.id.fab);
@@ -456,15 +461,6 @@ public class MainTabs2 extends AdsFragmentActivity {
             //drawerLayout.setDrawerLockMode(DrawerLayout.LOCK_MODE_LOCKED_CLOSED);
         } else {
             imageMenu.setVisibility(View.VISIBLE);
-        }
-
-        if (AppState.get().isEnableAccessibility) {
-            imageMenu.setVisibility(View.VISIBLE);
-        }
-
-
-        if(UITab.isShowLibrary()) {
-            imageMenu.setVisibility(View.GONE);
         }
 
         // ((BrigtnessDraw)
@@ -557,22 +553,8 @@ public class MainTabs2 extends AdsFragmentActivity {
         indicator.setBackgroundColor(TintUtil.color);
 
         if (!AppState.get().tapPositionTop || !AppState.get().tabWithNames) {
-            imageMenu.setVisibility(View.GONE);
             indicator.setDividerColors(Color.TRANSPARENT);
             indicator.setSelectedIndicatorColors(Color.TRANSPARENT);
-            for (int i = 0; i < indicator.getmTabStrip().getChildCount(); i++) {
-                View child = indicator.getmTabStrip().getChildAt(i);
-                child.setOnLongClickListener(new View.OnLongClickListener() {
-                    @Override
-                    public boolean onLongClick(View v) {
-                        imageMenu.performClick();
-                        return true;
-                    }
-                });
-            }
-        }
-        if (AppState.get().isEnableAccessibility) {
-            imageMenu.setVisibility(View.VISIBLE);
         }
 
         if (AppState.get().appTheme == AppState.THEME_INK) {
@@ -581,7 +563,6 @@ public class MainTabs2 extends AdsFragmentActivity {
             indicator.setDividerColors(TintUtil.color);
             indicator.setBackgroundColor(Color.TRANSPARENT);
             imageMenuParent.setBackgroundColor(Color.TRANSPARENT);
-
         }
 
 

--- a/app/src/main/java/com/foobnix/ui2/fragment/SearchFragment2.java
+++ b/app/src/main/java/com/foobnix/ui2/fragment/SearchFragment2.java
@@ -96,7 +96,7 @@ public class SearchFragment2 extends UIFragment<FileMeta> {
     AuthorsAdapter2 authorsAdapter;
     TextView countBooks, sortBy;
     Handler handler;
-    ImageView sortOrder, myAutoCompleteImage, cleanFilter, menu2;
+    ImageView sortOrder, myAutoCompleteImage, cleanFilter;
     View onRefresh, secondTopPanel;
     AutoCompleteTextView searchEditText;
     int countTitles = 0;
@@ -247,7 +247,6 @@ public class SearchFragment2 extends UIFragment<FileMeta> {
         int color = (AppState.get().appTheme == AppState.THEME_DARK_OLED ||
                         AppState.get().appTheme == AppState.THEME_DARK)
                         ? Color.WHITE : TintUtil.color;
-        TintUtil.setTintImageNoAlpha(menu2, color);
 
         int colorTheme = TintUtil.getColorInDayNighth();
         colorTheme = ColorUtils.setAlphaComponent(colorTheme, 230);
@@ -335,7 +334,6 @@ public class SearchFragment2 extends UIFragment<FileMeta> {
         cleanFilter = (ImageView) view.findViewById(R.id.cleanFilter);
         sortBy = (TextView) view.findViewById(R.id.sortBy);
         sortOrder = (ImageView) view.findViewById(R.id.sortOrder);
-        menu2 = (ImageView) view.findViewById(R.id.menu2);
         myAutoCompleteImage = (ImageView) view.findViewById(R.id.myAutoCompleteImage);
         searchEditText = (AutoCompleteTextView) view.findViewById(R.id.filterLine);
         recyclerView = (RecyclerView) view.findViewById(R.id.recyclerView);
@@ -486,15 +484,6 @@ public class SearchFragment2 extends UIFragment<FileMeta> {
             @Override
             public void onClick(View v) {
                 showAutoCompleteDialog();
-            }
-        });
-
-        menu2.setOnClickListener(new OnClickListener() {
-            @Override
-            public void onClick(View view) {
-                if (view.getRootView().findViewById(R.id.imageMenu1) != null) {
-                    view.getRootView().findViewById(R.id.imageMenu1).performClick();
-                }
             }
         });
 

--- a/app/src/main/res/layout/fragment_search2.xml
+++ b/app/src/main/res/layout/fragment_search2.xml
@@ -17,20 +17,6 @@
         android:gravity="center_vertical"
         android:orientation="horizontal" >
 
-        <ImageView
-            android:contentDescription="@string/cd_application_menu"
-            android:id="@+id/menu2"
-            android:padding="9dip"
-            android:adjustViewBounds="true"
-            android:cropToPadding="true"
-            android:layout_margin="0dip"
-            android:tint="@color/foobnix_light_blue"
-            android:layout_width="@dimen/wh_button"
-            android:layout_height="@dimen/wh_button"
-            android:src="@drawable/glyphicons_517_menu_hamburger" />
-
-
-
         <RelativeLayout
             android:layout_width="match_parent"
             android:layout_height="@dimen/wh_button"

--- a/app/src/main/res/layout/main_tabs.xml
+++ b/app/src/main/res/layout/main_tabs.xml
@@ -66,14 +66,37 @@
                         android:layout_height="match_parent"
                         android:layout_weight="1" />
 
-                    <com.foobnix.pdf.SlidingTabLayout
-                        android:id="@+id/slidingTabs2"
+                    <LinearLayout
+                        android:id="@+id/imageParent2"
                         android:layout_width="match_parent"
                         android:layout_height="wrap_content"
-                        android:layout_weight="0"
-                        android:background="#3949ab"
-                        android:elevation="2dip"
-                        android:visibility="gone"></com.foobnix.pdf.SlidingTabLayout>
+                        android:background="#0000ff"
+                        android:orientation="horizontal">
+
+                        <ImageView
+                            android:id="@+id/imageMenu2"
+
+                            android:layout_width="40dip"
+                            android:visibility="gone"
+                            android:layout_height="match_parent"
+                            android:layout_marginLeft="10dip"
+                            android:background="?android:attr/selectableItemBackground"
+                            android:contentDescription="@string/menu"
+                            android:gravity="center"
+                            android:padding="10dip"
+                            android:src="@drawable/glyphicons_517_menu_hamburger"
+                            android:tint="@color/white" />
+
+                        <com.foobnix.pdf.SlidingTabLayout
+                            android:id="@+id/slidingTabs2"
+                            android:layout_width="match_parent"
+                            android:layout_height="wrap_content"
+                            android:layout_weight="0"
+                            android:background="#3949ab"
+                            android:elevation="2dip"
+                            android:visibility="gone"></com.foobnix.pdf.SlidingTabLayout>
+
+                    </LinearLayout>
 
                 </LinearLayout>
 


### PR DESCRIPTION
1. Show tabs bottom with icon only and enable accessibility mode, application menu is the only icon in the top line of main tab.
2. Don't show library tab, show tabs with icon only, and disable accessibility mode, no entry for user to get application menu out except long press, but new user may not know this long press action.