### PR TITLE
Fix word breaks on newline.

### DIFF
--- a/Builder/jni/~mupdf-1.20.0/html-parse.c
+++ b/Builder/jni/~mupdf-1.20.0/html-parse.c
@@ -328,16 +328,7 @@ static void generate_text(fz_context *ctx, fz_html_box *box, const char *text, i
 
 	while (*text)
 	{
-		if (*text == '\n' || *text == '\r')
-		{
-			if (text[0] == '\r' && text[1] == '\n')
-				text += 2;
-			else
-				text += 1;
-			//add_flow_break(ctx, pool, flow, box);
-			//g->at_bol = 1;
-		}
-		else if (iswhite(*text))
+		if (iswhite(*text))
 		{
 			if (collapse)
 			{


### PR DESCRIPTION
As part of the fix for whitespace for mupdf 1.20 (commit
63ff786e208350f906b965b936296c4165392afe), a bug was introduced where
words separated only by newline characters would be merged.

This fixes that bug by entirely removing the dedicated handling of \n
and \r at the start of the loop in generate_text.

You can test this by viewing https://zelch.github.io/Test_Book.epub with both the current version of LibreraReader and the patched version, the first line should render correctly with both versions, the second two lines only render correctly with this update.