### PR TITLE
Don't mush words together in TTS

### DIFF
--- a/app/src/main/java/com/foobnix/tts/TTSService.java
+++ b/app/src/main/java/com/foobnix/tts/TTSService.java
@@ -582,8 +582,17 @@ public class TTSService extends Service {
             final String secondPart = pageNumber + 1 >= AppSP.get().lastBookPageCount || AppState.get().ttsTunnOnLastWord ? "" : parts[1];
 
             if (TxtUtils.isNotEmpty(preText)) {
-                preText = TxtUtils.replaceLast(preText, "-", "");
-                firstPart = preText + firstPart;
+                // Check to see if the last character is - from
+                // hyphenation; if it is, drop it.  If it isn't, add
+                // a space, to stop words from being smushed
+                // together.
+                char last = preText.charAt(preText.length() - 1);
+                if (last == '-') {
+                    preText = TxtUtils.replaceLast(preText, "-", "");
+                    firstPart = preText + firstPart;
+                } else {
+                    firstPart = preText + " " + firstPart;
+                }
             }
             final String preText1 = preText;
 


### PR DESCRIPTION
This issue only appears to happen when a page ends far from a period and
doesn't end in a hyphen, but when it happens it causes the last word of
one page to be prepended to the first word of the next page and then the
TTS engine tries to read it as one word and it's terrible.

Fixed by "either drop a - at the end or add a space at the end, then
append the next chunk".