### PR TITLE
Allow more stuff through the TTS processing

### DIFF
--- a/app/src/main/java/com/foobnix/android/utils/TxtUtils.java
+++ b/app/src/main/java/com/foobnix/android/utils/TxtUtils.java
@@ -361,10 +361,10 @@ public class TxtUtils {
 
 
         pageHTML = pageHTML.replace("<p>", " ").replace("</p>", " ");
-        pageHTML = pageHTML.replace("&nbsp;", " ").replace("&lt;", " ").replace("&gt;", "").replace("&amp;", " ").replace("&quot;", "\"");
-        pageHTML = pageHTML.replace("[image]", "");
+        pageHTML = pageHTML.replace("&nbsp;", " ").replace("&lt;", "<").replace("&gt;", ">").replace("&amp;", "&").replace("&quot;", "\"");
+        pageHTML = pageHTML.replace("[image]", "[image]");
 
-        LOG.d("pageHTML [2", pageHTML);
+        LOG.d("pageHTML [2]", pageHTML);
 
         pageHTML = pageHTML.replace("<end-line>.", ".");
 


### PR DESCRIPTION
As someone who uses TTS every day, often for technical material, having
information just disappear is really hard to deal with.  I'd much rather
have the information be there and use the replacement system to remove
it, especially since what I want to remove varies per book (example: in
my current book there's an image that's a user icon every couple of
paragraphs: I would very much want those to be skipped over; but in a
book about programming, "there's visual information you probably need
here" is extremely important).

This fix makes a decision for all users, obviously, but then so did the
previous code.  If that's not OK with you, Ivan, I'm happy to try to
figure how to make this a config option in the TTS dialogue instead.