### PR TITLE
Add intent TTS_SERVICE to fix tts issue.

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -10,7 +10,6 @@
 
     <uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE" />
     <uses-permission android:name="android.permission.MANAGE_EXTERNAL_STORAGE" />
-    <uses-permission android:name="android.permission.QUERY_ALL_PACKAGES" />
 
     <uses-permission android:name="android.permission.VIBRATE" />
     <uses-permission android:name="android.permission.WAKE_LOCK" />
@@ -33,6 +32,9 @@
         </intent>
         <intent>
             <action android:name="android.intent.action.SEARCH" />
+        </intent>
+        <intent>
+          <action android:name="android.intent.action.TTS_SERVICE" />
         </intent>
     </queries>
 

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -10,6 +10,7 @@
 
     <uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE" />
     <uses-permission android:name="android.permission.MANAGE_EXTERNAL_STORAGE" />
+    <uses-permission android:name="android.permission.QUERY_ALL_PACKAGES" />
 
     <uses-permission android:name="android.permission.VIBRATE" />
     <uses-permission android:name="android.permission.WAKE_LOCK" />


### PR DESCRIPTION
Without permission to query all package only `speech services by Google` is detected. To allow rhvoice and other TTS engine `QUERY_ALL_PACKAGE`  permission is required. This can also be achieved by action `TTS_SERVICE` as per the official [docs](https://developer.android.com/reference/android/speech/tts/TextToSpeech).

Fixes #888 

[Release Artifacts](https://github.com/sak96/LibreraReader/releases/tag/8.6.15-fixtts.0)