### PR TITLE
Use WindowCompat to show/hide the navigation bar.

### DIFF
--- a/app/src/main/java/com/foobnix/android/utils/Keyboards.java
+++ b/app/src/main/java/com/foobnix/android/utils/Keyboards.java
@@ -1,14 +1,21 @@
 package com.foobnix.android.utils;
 
+import static com.foobnix.androidx.core.view.WindowInsetsControllerCompat.BEHAVIOR_SHOW_TRANSIENT_BARS_BY_SWIPE;
+
 import android.app.Activity;
 import android.content.Context;
 import android.os.Build;
 import android.os.Handler;
 import android.os.Looper;
 import android.view.View;
+import android.view.Window;
 import android.view.WindowManager;
 import android.view.inputmethod.InputMethodManager;
 
+import androidx.core.view.WindowInsetsCompat;
+
+import com.foobnix.androidx.core.view.WindowCompat;
+import com.foobnix.androidx.core.view.WindowInsetsControllerCompat;
 import com.foobnix.model.AppState;
 import com.foobnix.ui2.MainTabs2;
 
@@ -69,42 +76,35 @@ public class Keyboards {
 
     }
 
-    public static void hideNavigation(final Activity a) {
+    public static void hideNavigation(final Activity activity) {
         try {
-            if (a == null) {
+            if (activity == null) {
                 return;
             }
-            if (a instanceof MainTabs2 && AppState.get().fullScreenMainMode == AppState.FULL_SCREEN_NORMAL) {
+            if (activity instanceof MainTabs2
+                    && AppState.get().fullScreenMainMode == AppState.FULL_SCREEN_NORMAL) {
                 return;
             } else if (AppState.get().fullScreenMode == AppState.FULL_SCREEN_NORMAL) {
                 return;
             }
 
-            final View decorView = a.getWindow().getDecorView();
-            decorView.postDelayed(new Runnable() {
+            final Window window = activity.getWindow();
+            final View decorView = window.getDecorView();
+            final WindowInsetsControllerCompat insetsController = WindowCompat
+                    .getInsetsController(window, decorView);
 
-                @Override
-                public void run() {
-                    if (Build.VERSION.SDK_INT >= 19) {
-                        decorView.setSystemUiVisibility(//
-                                View.SYSTEM_UI_FLAG_LAYOUT_STABLE //
-                                        | View.SYSTEM_UI_FLAG_LAYOUT_HIDE_NAVIGATION//
-                                        | View.SYSTEM_UI_FLAG_LAYOUT_FULLSCREEN//
-                                        | View.SYSTEM_UI_FLAG_HIDE_NAVIGATION//
-                                        | View.SYSTEM_UI_FLAG_FULLSCREEN//
-                                        | View.SYSTEM_UI_FLAG_IMMERSIVE_STICKY);//
-                    } else {
-                        decorView.setSystemUiVisibility( //
-                                View.SYSTEM_UI_FLAG_LOW_PROFILE //
-                                        | View.SYSTEM_UI_FLAG_FULLSCREEN); //
-                    }
+            decorView.postDelayed(() -> {
+                if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.JELLY_BEAN) {
+                    WindowCompat.setDecorFitsSystemWindows(window, false);
+                    insetsController.setSystemBarsBehavior(BEHAVIOR_SHOW_TRANSIENT_BARS_BY_SWIPE);
+                } else {
+                    insetsController.hide(WindowInsetsCompat.Type.navigationBars()
+                            | WindowInsetsCompat.Type.statusBars());
                 }
-
             }, 100);
         } catch (Exception e) {
             LOG.e(e);
         }
-
     }
 
     public static void hideNavigationOnCreate(final Activity a) {
@@ -112,24 +112,19 @@ public class Keyboards {
             if (AppState.get().fullScreenMode == AppState.FULL_SCREEN_NORMAL) {
                 return;
             }
-            final View decorView = a.getWindow().getDecorView();
-            if (Build.VERSION.SDK_INT >= 19) {
-                decorView.setSystemUiVisibility(//
-                        View.SYSTEM_UI_FLAG_LAYOUT_STABLE //
-                                | View.SYSTEM_UI_FLAG_LAYOUT_HIDE_NAVIGATION//
-                                | View.SYSTEM_UI_FLAG_LAYOUT_FULLSCREEN//
-                                | View.SYSTEM_UI_FLAG_HIDE_NAVIGATION//
-                                | View.SYSTEM_UI_FLAG_FULLSCREEN//
-                                | View.SYSTEM_UI_FLAG_IMMERSIVE_STICKY);//
+            final Window window = a.getWindow();
+            final WindowInsetsControllerCompat insetsController = WindowCompat
+                    .getInsetsController(window, window.getDecorView());
+
+            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.JELLY_BEAN) {
+                WindowCompat.setDecorFitsSystemWindows(window, false);
+                insetsController.setSystemBarsBehavior(BEHAVIOR_SHOW_TRANSIENT_BARS_BY_SWIPE);
             } else {
-                decorView.setSystemUiVisibility( //
-                        View.SYSTEM_UI_FLAG_LOW_PROFILE //
-                                | View.SYSTEM_UI_FLAG_FULLSCREEN); //
+                insetsController.hide(WindowInsetsCompat.Type.navigationBars()
+                        | WindowInsetsCompat.Type.statusBars());
             }
         } catch (Exception e) {
             LOG.e(e);
         }
-
     }
-
 }

--- a/app/src/main/java/com/foobnix/androidx/core/view/WindowCompat.java
+++ b/app/src/main/java/com/foobnix/androidx/core/view/WindowCompat.java
@@ -1,0 +1,186 @@
+/*
+ * Copyright 2018 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.foobnix.androidx.core.view;
+
+import android.app.Activity;
+import android.graphics.Rect;
+import android.os.Build;
+import android.view.View;
+import android.view.Window;
+
+import androidx.annotation.DoNotInline;
+import androidx.annotation.IdRes;
+import androidx.annotation.NonNull;
+import androidx.annotation.RequiresApi;
+import androidx.core.view.ViewCompat;
+import androidx.core.view.WindowInsetsCompat;
+
+/**
+ * Helper for accessing features in {@link Window}.
+ */
+public final class WindowCompat {
+    /**
+     * Flag for enabling the Action Bar.
+     * This is enabled by default for some devices. The Action Bar
+     * replaces the title bar and provides an alternate location
+     * for an on-screen menu button on some devices.
+     */
+    public static final int FEATURE_ACTION_BAR = 8;
+
+    /**
+     * Flag for requesting an Action Bar that overlays window content.
+     * Normally an Action Bar will sit in the space above window content, but if this
+     * feature is requested along with {@link #FEATURE_ACTION_BAR} it will be layered over
+     * the window content itself. This is useful if you would like your app to have more control
+     * over how the Action Bar is displayed, such as letting application content scroll beneath
+     * an Action Bar with a transparent background or otherwise displaying a transparent/translucent
+     * Action Bar over application content.
+     *
+     * <p>This mode is especially useful with {@link View#SYSTEM_UI_FLAG_FULLSCREEN
+     * View.SYSTEM_UI_FLAG_FULLSCREEN}, which allows you to seamlessly hide the
+     * action bar in conjunction with other screen decorations.
+     *
+     * <p>As of {@link Build.VERSION_CODES#JELLY_BEAN}, when an
+     * ActionBar is in this mode it will adjust the insets provided to
+     * {@link View#fitSystemWindows(Rect) View.fitSystemWindows(Rect)}
+     * to include the content covered by the action bar, so you can do layout within
+     * that space.
+     */
+    public static final int FEATURE_ACTION_BAR_OVERLAY = 9;
+
+    /**
+     * Flag for specifying the behavior of action modes when an Action Bar is not present.
+     * If overlay is enabled, the action mode UI will be allowed to cover existing window content.
+     */
+    public static final int FEATURE_ACTION_MODE_OVERLAY = 10;
+
+    private WindowCompat() {}
+
+    /**
+     * Finds a view that was identified by the {@code android:id} XML attribute
+     * that was processed in {@link Activity#onCreate}, or throws an
+     * IllegalArgumentException if the ID is invalid, or there is no matching view in the hierarchy.
+     * <p>
+     * <strong>Note:</strong> In most cases -- depending on compiler support --
+     * the resulting view is automatically cast to the target class type. If
+     * the target class type is unconstrained, an explicit cast may be
+     * necessary.
+     *
+     * @param id the ID to search for
+     * @return a view with given ID
+     * @see ViewCompat#requireViewById(View, int)
+     * @see Window#findViewById(int)
+     */
+    @SuppressWarnings("TypeParameterUnusedInFormals")
+    @NonNull
+    public static <T extends View> T requireViewById(@NonNull Window window, @IdRes int id) {
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.P) {
+            return Api28Impl.requireViewById(window, id);
+        }
+
+        T view = window.findViewById(id);
+        if (view == null) {
+            throw new IllegalArgumentException("ID does not reference a View inside this Window");
+        }
+        return view;
+    }
+
+    /**
+     * Sets whether the decor view should fit root-level content views for
+     * {@link WindowInsetsCompat}.
+     * <p>
+     * If set to {@code false}, the framework will not fit the content view to the insets and will
+     * just pass through the {@link WindowInsetsCompat} to the content view.
+     * </p>
+     * <p>
+     * Please note: using the {@link View#setSystemUiVisibility(int)} API in your app can
+     * conflict with this method. Please discontinue use of {@link View#setSystemUiVisibility(int)}.
+     * </p>
+     *
+     * @param window                 The current window.
+     * @param decorFitsSystemWindows Whether the decor view should fit root-level content views for
+     *                               insets.
+     */
+    public static void setDecorFitsSystemWindows(@NonNull Window window,
+                                                 final boolean decorFitsSystemWindows) {
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.R) {
+            Api30Impl.setDecorFitsSystemWindows(window, decorFitsSystemWindows);
+        } else if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.JELLY_BEAN) {
+            Api16Impl.setDecorFitsSystemWindows(window, decorFitsSystemWindows);
+        }
+    }
+
+    /**
+     * Retrieves the single {@link WindowInsetsControllerCompat} of the window this view is attached
+     * to.
+     *
+     * @return The {@link WindowInsetsControllerCompat} for the window.
+     * @see Window#getInsetsController()
+     */
+    @NonNull
+    public static WindowInsetsControllerCompat getInsetsController(@NonNull Window window,
+                                                                   @NonNull View view) {
+        return new WindowInsetsControllerCompat(window, view);
+    }
+
+    @RequiresApi(Build.VERSION_CODES.JELLY_BEAN)
+    static class Api16Impl {
+        private Api16Impl() {
+            // This class is not instantiable.
+        }
+
+        @SuppressWarnings("deprecation")
+        @DoNotInline
+        static void setDecorFitsSystemWindows(@NonNull Window window,
+                                              final boolean decorFitsSystemWindows) {
+            final int decorFitsFlags = View.SYSTEM_UI_FLAG_LAYOUT_STABLE
+                    | View.SYSTEM_UI_FLAG_LAYOUT_HIDE_NAVIGATION
+                    | View.SYSTEM_UI_FLAG_LAYOUT_FULLSCREEN;
+
+            final View decorView = window.getDecorView();
+            final int sysUiVis = decorView.getSystemUiVisibility();
+            decorView.setSystemUiVisibility(decorFitsSystemWindows ? sysUiVis & ~decorFitsFlags
+                    : sysUiVis | decorFitsFlags);
+        }
+    }
+
+    @RequiresApi(Build.VERSION_CODES.P)
+    static class Api28Impl {
+        private Api28Impl() {
+            // This class is not instantiable.
+        }
+
+        @SuppressWarnings({"unchecked", "TypeParameterUnusedInFormals"})
+        @DoNotInline
+        static <T> T requireViewById(Window window, int id) {
+            return (T) window.requireViewById(id);
+        }
+    }
+
+    @RequiresApi(Build.VERSION_CODES.R)
+    static class Api30Impl {
+        private Api30Impl() {
+            // This class is not instantiable.
+        }
+
+        @DoNotInline
+        static void setDecorFitsSystemWindows(@NonNull Window window,
+                                              final boolean decorFitsSystemWindows) {
+            window.setDecorFitsSystemWindows(decorFitsSystemWindows);
+        }
+    }
+}

--- a/app/src/main/java/com/foobnix/androidx/core/view/WindowInsetsAnimationControlListenerCompat.java
+++ b/app/src/main/java/com/foobnix/androidx/core/view/WindowInsetsAnimationControlListenerCompat.java
@@ -1,0 +1,92 @@
+/*
+ * Copyright (C) 2018 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.foobnix.androidx.core.view;
+
+import android.view.inputmethod.EditorInfo;
+
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
+import androidx.core.view.WindowInsetsCompat.Type;
+import androidx.core.view.WindowInsetsCompat.Type.InsetsType;
+
+/**
+ * Listener that encapsulates a request to
+ * {@link WindowInsetsControllerCompat#controlWindowInsetsAnimation}.
+ *
+ * <p>
+ * Insets can be controlled with the supplied {@link WindowInsetsAnimationControllerCompat} from
+ * {@link #onReady} until either {@link #onFinished} or {@link #onCancelled}.
+ *
+ * <p>
+ * Once the control over insets is finished or cancelled, it will not be regained until a new
+ * request to {@link WindowInsetsControllerCompat#controlWindowInsetsAnimation} is made.
+ *
+ * <p>
+ * The request to control insets can fail immediately. In that case {@link #onCancelled} will be
+ * invoked without a preceding {@link #onReady}.
+ *
+ * @see WindowInsetsControllerCompat#controlWindowInsetsAnimation
+ */
+public interface WindowInsetsAnimationControlListenerCompat {
+
+    /**
+     * Called when the animation is ready to be controlled. This may be delayed when the IME needs
+     * to redraw because of an {@link EditorInfo} change, or when the window is starting up.
+     *
+     * @param controller The controller to control the inset animation.
+     * @param types      The {@link Type}s it was able to gain control over. Note that this
+     *                   may be different than the types passed into
+     *                   {@link WindowInsetsControllerCompat#controlWindowInsetsAnimation} in
+     *                   case the window wasn't able to gain the controls because it wasn't the
+     *                   IME target or not currently the window that's controlling the system bars.
+     * @see WindowInsetsAnimationControllerCompat#isReady
+     */
+    void onReady(@NonNull WindowInsetsAnimationControllerCompat controller, @InsetsType int types);
+
+    /**
+     * Called when the request for control over the insets has
+     * {@link WindowInsetsAnimationControllerCompat#finish finished}.
+     * <p>
+     * Once this callback is invoked, the supplied {@link WindowInsetsAnimationControllerCompat}
+     * is no longer {@link WindowInsetsAnimationControllerCompat#isReady() ready}.
+     * <p>
+     * Control will not be regained until a new request
+     * to {@link WindowInsetsControllerCompat#controlWindowInsetsAnimation} is made.
+     *
+     * @param controller the controller which has finished.
+     * @see WindowInsetsAnimationControllerCompat#isFinished
+     */
+    void onFinished(@NonNull WindowInsetsAnimationControllerCompat controller);
+
+    /**
+     * Called when the request for control over the insets has been cancelled, either
+     * because the {@link android.os.CancellationSignal} associated with the
+     * {@link WindowInsetsControllerCompat#controlWindowInsetsAnimation request} has been
+     * invoked, or the window has lost control over the insets (e.g. because it lost focus).
+     * <p>
+     * Once this callback is invoked, the supplied {@link WindowInsetsAnimationControllerCompat}
+     * is no longer {@link WindowInsetsAnimationControllerCompat#isReady() ready}.
+     * <p>
+     * Control will not be regained until a new request
+     * to {@link WindowInsetsControllerCompat#controlWindowInsetsAnimation} is made.
+     *
+     * @param controller the controller which has been cancelled, or null if the request
+     *                   was cancelled before {@link #onReady} was invoked.
+     * @see WindowInsetsAnimationControllerCompat#isCancelled
+     */
+    void onCancelled(@Nullable WindowInsetsAnimationControllerCompat controller);
+}

--- a/app/src/main/java/com/foobnix/androidx/core/view/WindowInsetsAnimationControllerCompat.java
+++ b/app/src/main/java/com/foobnix/androidx/core/view/WindowInsetsAnimationControllerCompat.java
@@ -1,0 +1,360 @@
+/*
+ * Copyright 2020 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.foobnix.androidx.core.view;
+
+import android.os.Build;
+import android.view.View;
+import android.view.WindowInsetsAnimationController;
+
+import androidx.annotation.FloatRange;
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
+import androidx.annotation.RequiresApi;
+import androidx.core.graphics.Insets;
+import androidx.core.view.ViewCompat;
+import androidx.core.view.WindowInsetsAnimationCompat;
+import androidx.core.view.WindowInsetsCompat.Type;
+import androidx.core.view.WindowInsetsCompat.Type.InsetsType;
+
+
+/**
+ * Controller for app-driven animation of system windows.
+ * <p>
+ * {@code WindowInsetsAnimationController} lets apps animate system windows such as
+ * the {@link android.inputmethodservice.InputMethodService IME}. The animation is
+ * synchronized, such that changes the system windows and the app's current frame
+ * are rendered at the same time.
+ * <p>
+ * Control is obtained through {@link WindowInsetsControllerCompat#controlWindowInsetsAnimation}.
+ */
+public final class WindowInsetsAnimationControllerCompat {
+    private final Impl mImpl;
+
+    WindowInsetsAnimationControllerCompat() {
+        if (Build.VERSION.SDK_INT < 30) {
+            mImpl = new Impl();
+        } else {
+            throw new UnsupportedOperationException("On API 30+, the constructor taking a "
+                    + WindowInsetsAnimationController.class.getSimpleName() + " as parameter");
+        }
+    }
+
+    @RequiresApi(30)
+    WindowInsetsAnimationControllerCompat(
+            @NonNull WindowInsetsAnimationController controller) {
+        mImpl = new Impl30(controller);
+    }
+
+    /**
+     * Retrieves the {@link Insets} when the windows this animation is controlling are fully hidden.
+     * <p>
+     * Note that these insets are always relative to the window, which is the same as being relative
+     * to {@link View#getRootView}
+     * <p>
+     * If there are any animation listeners registered, this value is the same as
+     * {@link WindowInsetsAnimationCompat.BoundsCompat#getLowerBound()} that is being be passed
+     * into the root view of the hierarchy.
+     *
+     * @return Insets when the windows this animation is controlling are fully hidden.
+     * @see WindowInsetsAnimationCompat.BoundsCompat#getLowerBound()
+     */
+    @NonNull
+    public Insets getHiddenStateInsets() {
+        return mImpl.getHiddenStateInsets();
+    }
+
+    /**
+     * Retrieves the {@link Insets} when the windows this animation is
+     * controlling are fully shown.
+     * <p>
+     * Note that these insets are always relative to the window, which is the same as being relative
+     * to {@link View#getRootView}
+     * <p>
+     * If there are any animation listeners registered, this value is the same as
+     * {@link WindowInsetsAnimationCompat.BoundsCompat#getUpperBound()} that is being passed
+     * into the root view of hierarchy.
+     *
+     * @return Insets when the windows this animation is controlling are fully shown.
+     * @see WindowInsetsAnimationCompat.BoundsCompat#getUpperBound()
+     */
+    @NonNull
+    public Insets getShownStateInsets() {
+        return mImpl.getShownStateInsets();
+    }
+
+    /**
+     * Retrieves the current insets.
+     * <p>
+     * Note that these insets are always relative to the window, which is the same as
+     * being relative
+     * to {@link View#getRootView}
+     *
+     * @return The current insets on the currently showing frame. These insets will change as the
+     * animation progresses to reflect the current insets provided by the controlled window.
+     */
+    @NonNull
+    public Insets getCurrentInsets() {
+        return mImpl.getCurrentInsets();
+    }
+
+    /**
+     * Returns the progress as previously set by {@code fraction} in {@link #setInsetsAndAlpha}
+     *
+     * @return the progress of the animation, where {@code 0} is fully hidden and {@code 1} is
+     * fully shown.
+     * <p>
+     * Note: this value represents raw overall progress of the animation
+     * i.e. the combined progress of insets and alpha.
+     * <p>
+     */
+    @FloatRange(from = 0f, to = 1f)
+    public float getCurrentFraction() {
+        return mImpl.getCurrentFraction();
+    }
+
+    /**
+     * Current alpha value of the window.
+     *
+     * @return float value between 0 and 1.
+     */
+    public float getCurrentAlpha() {
+        return mImpl.getCurrentAlpha();
+    }
+
+    /**
+     * @return The {@link Type}s this object is currently controlling.
+     */
+    @InsetsType
+    public int getTypes() {
+        return mImpl.getTypes();
+    }
+
+    /**
+     * Modifies the insets for the frame being drawn by indirectly moving the windows around in the
+     * system that are causing window insets.
+     * <p>
+     * Note that these insets are always relative to the window, which is the same as being relative
+     * to {@link View#getRootView}
+     * <p>
+     * Also note that this will <b>not</b> inform the view system of a full inset change via
+     * {@link View#dispatchApplyWindowInsets} in order to avoid a full layout pass during the
+     * animation. If you'd like to animate views during a window inset animation, register a
+     * {@link WindowInsetsAnimationCompat.Callback} by calling
+     *
+     * {@link ViewCompat#setWindowInsetsAnimationCallback(View,
+     * WindowInsetsAnimationCompat.Callback)}
+     * that will be notified about any insets change via
+     * {@link WindowInsetsAnimationCompat.Callback#onProgress} during the animation.
+     * <p>
+     * {@link View#dispatchApplyWindowInsets} will instead be called once the animation has
+     * finished, i.e. once {@link #finish} has been called.
+     * Note: If there are no insets, alpha animation is still applied.
+     *
+     * @param insets   The new insets to apply. Based on the requested insets, the system will
+     *                 calculate the positions of the windows in the system causing insets such that
+     *                 the resulting insets of that configuration will match the passed in
+     *                 parameter.
+     *                 Note that these insets are being clamped to the range from
+     *                 {@link #getHiddenStateInsets} to {@link #getShownStateInsets}.
+     *                 If you intend on changing alpha only, pass null or
+     *                 {@link #getCurrentInsets()}.
+     * @param alpha    The new alpha to apply to the inset side.
+     * @param fraction instantaneous animation progress. This value is dispatched to
+     *                 {@link WindowInsetsAnimationCompat.Callback}.
+     * @see WindowInsetsAnimationCompat.Callback
+     * @see ViewCompat#setWindowInsetsAnimationCallback(View, WindowInsetsAnimationCompat.Callback)
+     */
+    public void setInsetsAndAlpha(@Nullable Insets insets,
+                                  @FloatRange(from = 0f, to = 1f) float alpha,
+                                  @FloatRange(from = 0f, to = 1f) float fraction) {
+        mImpl.setInsetsAndAlpha(insets, alpha, fraction);
+    }
+
+    /**
+     * Finishes the animation, and leaves the windows shown or hidden.
+     * <p>
+     * After invoking {@link #finish}, this instance is no longer {@link #isReady ready}.
+     * <p>
+     * Note: Finishing an animation implicitly {@link #setInsetsAndAlpha sets insets and alpha}
+     * according to the requested end state without any further animation.
+     *
+     * @param shown if {@code true}, the windows will be shown after finishing the
+     *              animation. Otherwise they will be hidden.
+     */
+    public void finish(boolean shown) {
+        mImpl.finish(shown);
+    }
+
+    /**
+     * Returns whether this instance is ready to be used to control window insets.
+     * <p>
+     * Instances are ready when passed in {@link WindowInsetsAnimationControlListenerCompat#onReady}
+     * and stop being ready when it is either {@link #isFinished() finished} or
+     * {@link #isCancelled() cancelled}.
+     *
+     * @return {@code true} if the instance is ready, {@code false} otherwise.
+     */
+
+    public boolean isReady() {
+        return !isFinished() && !isCancelled();
+    }
+
+    /**
+     * Returns whether this instance has been finished by a call to {@link #finish}.
+     *
+     * @return {@code true} if the instance is finished, {@code false} otherwise.
+     * @see WindowInsetsAnimationControlListenerCompat#onFinished
+     */
+    public boolean isFinished() {
+        return mImpl.isFinished();
+    }
+
+    /**
+     * Returns whether this instance has been cancelled by the system, or by invoking the
+     * {@link android.os.CancellationSignal} passed into
+     * {@link WindowInsetsControllerCompat#controlWindowInsetsAnimation}.
+     *
+     * @return {@code true} if the instance is cancelled, {@code false} otherwise.
+     * @see WindowInsetsAnimationControlListenerCompat#onCancelled
+     */
+    public boolean isCancelled() {
+        return mImpl.isCancelled();
+    }
+
+    private static class Impl {
+        Impl() {
+            //privatex
+        }
+
+        @NonNull
+        public Insets getHiddenStateInsets() {
+            return Insets.NONE;
+        }
+
+        @NonNull
+        public Insets getShownStateInsets() {
+            return Insets.NONE;
+        }
+
+        @NonNull
+        public Insets getCurrentInsets() {
+            return Insets.NONE;
+        }
+
+        @FloatRange(from = 0f, to = 1f)
+        public float getCurrentFraction() {
+            return 0f;
+        }
+
+        public float getCurrentAlpha() {
+            return 0f;
+        }
+
+        @InsetsType
+        public int getTypes() {
+            return 0;
+        }
+
+        public void setInsetsAndAlpha(@Nullable Insets insets,
+                                      @FloatRange(from = 0f, to = 1f) float alpha,
+                                      @FloatRange(from = 0f, to = 1f) float fraction) {
+        }
+
+        void finish(boolean shown) {
+        }
+
+        public boolean isReady() {
+            return false;
+        }
+
+        boolean isFinished() {
+            return false;
+        }
+
+        boolean isCancelled() {
+            return true;
+        }
+    }
+
+    @RequiresApi(30)
+    private static class Impl30 extends Impl {
+        private final WindowInsetsAnimationController mController;
+
+        Impl30(@NonNull WindowInsetsAnimationController controller) {
+            mController = controller;
+        }
+
+        @NonNull
+        @Override
+        public Insets getHiddenStateInsets() {
+            return Insets.toCompatInsets(mController.getHiddenStateInsets());
+        }
+
+        @NonNull
+        @Override
+        public Insets getShownStateInsets() {
+            return Insets.toCompatInsets(mController.getShownStateInsets());
+        }
+
+        @NonNull
+        @Override
+        public Insets getCurrentInsets() {
+            return Insets.toCompatInsets(mController.getCurrentInsets());
+        }
+
+        @Override
+        public float getCurrentFraction() {
+            return mController.getCurrentFraction();
+        }
+
+        @Override
+        public float getCurrentAlpha() {
+            return mController.getCurrentAlpha();
+        }
+
+        @Override
+        public int getTypes() {
+            return mController.getTypes();
+        }
+
+        @Override
+        public void setInsetsAndAlpha(@Nullable Insets insets, float alpha, float fraction) {
+            mController.setInsetsAndAlpha(insets == null ? null : insets.toPlatformInsets(),
+                    alpha, fraction);
+        }
+
+        @Override
+        void finish(boolean shown) {
+            mController.finish(shown);
+        }
+
+        @Override
+        public boolean isReady() {
+            return mController.isReady();
+        }
+
+        @Override
+        boolean isFinished() {
+            return mController.isFinished();
+        }
+
+        @Override
+        boolean isCancelled() {
+            return mController.isCancelled();
+        }
+    }
+}

--- a/app/src/main/java/com/foobnix/androidx/core/view/WindowInsetsControllerCompat.java
+++ b/app/src/main/java/com/foobnix/androidx/core/view/WindowInsetsControllerCompat.java
@@ -1,0 +1,772 @@
+/*
+ * Copyright 2020 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.foobnix.androidx.core.view;
+
+import android.annotation.SuppressLint;
+import android.inputmethodservice.InputMethodService;
+import android.os.Build;
+import android.view.View;
+import android.view.Window;
+import android.view.WindowInsets;
+import android.view.WindowInsetsAnimationControlListener;
+import android.view.WindowInsetsAnimationController;
+import android.view.WindowInsetsController;
+import android.view.WindowManager;
+import android.view.animation.Interpolator;
+import android.view.inputmethod.InputMethodManager;
+
+import androidx.annotation.IntDef;
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
+import androidx.annotation.RequiresApi;
+import androidx.annotation.RestrictTo;
+import androidx.collection.SimpleArrayMap;
+import androidx.core.content.ContextCompat;
+import androidx.core.graphics.Insets;
+import androidx.core.os.CancellationSignal;
+import androidx.core.view.WindowInsetsAnimationCompat;
+import androidx.core.view.WindowInsetsCompat;
+import androidx.core.view.WindowInsetsCompat.Type.InsetsType;
+
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.util.concurrent.TimeUnit;
+
+/**
+ * Provide simple controls of windows that generate insets.
+ *
+ * For SDKs >= 30, this class is a simple wrapper around {@link WindowInsetsController}. For
+ * lower SDKs, this class aims to behave as close as possible to the original implementation.
+ */
+// The AndroidX class doesn't include implementations for API levels < 20, so this is needed.
+public final class WindowInsetsControllerCompat {
+    /**
+     * The default option for {@link #setSystemBarsBehavior(int)}. System bars will be forcibly
+     * shown on any user interaction on the corresponding display if navigation bars are hidden
+     * by {@link #hide(int)} or
+     * {@link WindowInsetsAnimationControllerCompat#setInsetsAndAlpha(Insets, float, float)}.
+     */
+    public static final int BEHAVIOR_SHOW_BARS_BY_TOUCH = 0;
+
+    /**
+     * Option for {@link #setSystemBarsBehavior(int)}: Window would like to remain interactive
+     * when hiding navigation bars by calling {@link #hide(int)} or
+     * {@link WindowInsetsAnimationControllerCompat#setInsetsAndAlpha(Insets, float, float)}.
+     * <p>
+     * When system bars are hidden in this mode, they can be revealed with system
+     * gestures, such as swiping from the edge of the screen where the bar is hidden from.
+     */
+    public static final int BEHAVIOR_SHOW_BARS_BY_SWIPE = 1;
+
+    /**
+     * Option for {@link #setSystemBarsBehavior(int)}: Window would like to remain
+     * interactive when hiding navigation bars by calling {@link #hide(int)} or
+     * {@link WindowInsetsAnimationControllerCompat#setInsetsAndAlpha(Insets, float, float)}.
+     * <p>
+     * When system bars are hidden in this mode, they can be revealed temporarily with system
+     * gestures, such as swiping from the edge of the screen where the bar is hidden from. These
+     * transient system bars will overlay app’s content, may have some degree of
+     * transparency, and will automatically hide after a short timeout.
+     */
+    public static final int BEHAVIOR_SHOW_TRANSIENT_BARS_BY_SWIPE = 2;
+
+    private final Impl mImpl;
+
+    public WindowInsetsControllerCompat(@NonNull Window window, @NonNull View view) {
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.R) {
+            mImpl = new Impl30(window, this);
+        } else if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
+            mImpl = new Impl26(window, view);
+        } else if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M) {
+            mImpl = new Impl23(window, view);
+        } else if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.KITKAT) {
+            mImpl = new Impl19(window, view);
+        } else if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.JELLY_BEAN) {
+            mImpl = new Impl16(window, view);
+        } else {
+            mImpl = new Impl14(window, view);
+        }
+    }
+
+    /**
+     * Determines the behavior of system bars when hiding them by calling {@link #hide}.
+     *
+     * @hide
+     */
+    @RestrictTo(RestrictTo.Scope.LIBRARY)
+    @Retention(RetentionPolicy.SOURCE)
+    @IntDef(value = {BEHAVIOR_SHOW_BARS_BY_TOUCH, BEHAVIOR_SHOW_BARS_BY_SWIPE,
+            BEHAVIOR_SHOW_TRANSIENT_BARS_BY_SWIPE})
+    @interface Behavior {
+    }
+
+    /**
+     * Makes a set of windows that cause insets appear on screen.
+     * <p>
+     * Note that if the window currently doesn't have control over a certain type, it will apply the
+     * change as soon as the window gains control. The app can listen to the event by observing
+     * {@link View#onApplyWindowInsets} and checking visibility with {@link WindowInsets#isVisible}.
+     *
+     * @param types A bitmask of {@link WindowInsetsCompat.Type} specifying what windows the app
+     *              would like to make appear on screen.
+     */
+    public void show(@InsetsType int types) {
+        mImpl.show(types);
+    }
+
+    /**
+     * Makes a set of windows causing insets disappear.
+     * <p>
+     * Note that if the window currently doesn't have control over a certain type, it will apply the
+     * change as soon as the window gains control. The app can listen to the event by observing
+     * {@link View#onApplyWindowInsets} and checking visibility with {@link WindowInsets#isVisible}.
+     *
+     * @param types A bitmask of {@link WindowInsetsCompat.Type} specifying what windows the app
+     *              would like to make disappear.
+     */
+    public void hide(@InsetsType int types) {
+        mImpl.hide(types);
+    }
+
+    /**
+     * Checks if the foreground of the status bar is set to light.
+     * <p>
+     * This method always returns false on API < 23.
+     *
+     * @return true if the foreground is light
+     * @see #setAppearanceLightStatusBars(boolean)
+     */
+    public boolean isAppearanceLightStatusBars() {
+        return mImpl.isAppearanceLightStatusBars();
+    }
+
+    /**
+     * If true, changes the foreground color of the status bars to light so that the items on the
+     * bar can be read clearly. If false, reverts to the default appearance.
+     * <p>
+     * This method has no effect on API < 23.
+     *
+     * @see #isAppearanceLightStatusBars()
+     */
+    public void setAppearanceLightStatusBars(boolean isLight) {
+        mImpl.setAppearanceLightStatusBars(isLight);
+    }
+
+    /**
+     * Checks if the foreground of the navigation bar is set to light.
+     * <p>
+     * This method always returns false on API < 26.
+     *
+     * @return true if the foreground is light
+     * @see #setAppearanceLightNavigationBars(boolean)
+     */
+    public boolean isAppearanceLightNavigationBars() {
+        return mImpl.isAppearanceLightNavigationBars();
+    }
+
+    /**
+     * If true, changes the foreground color of the navigation bars to light so that the items on
+     * the bar can be read clearly. If false, reverts to the default appearance.
+     * <p>
+     * This method has no effect on API < 26.
+     *
+     * @see #isAppearanceLightNavigationBars()
+     */
+    public void setAppearanceLightNavigationBars(boolean isLight) {
+        mImpl.setAppearanceLightNavigationBars(isLight);
+    }
+
+    /**
+     * Lets the application control window inset animations in a frame-by-frame manner by
+     * modifying the position of the windows in the system causing insets directly using
+     * {@link WindowInsetsAnimationControllerCompat#setInsetsAndAlpha} in the controller provided
+     * by the given listener.
+     * <p>
+     * This method only works on API >= 30 since there is no way to control the window in the
+     * system on prior APIs.
+     *
+     * @param types              The {@link WindowInsetsCompat.Type}s the application has
+     *                           requested to control.
+     * @param durationMillis     Duration of animation in {@link TimeUnit#MILLISECONDS}, or -1 if
+     *                           the animation doesn't have a predetermined duration. This value
+     *                           will be passed to
+     *                           {@link WindowInsetsAnimationCompat#getDurationMillis()}
+     * @param interpolator       The interpolator used for this animation, or {@code null } if
+     *                           this animation doesn't follow an interpolation curve. This value
+     *                           will be passed to
+     *                           {@link WindowInsetsAnimationCompat#getInterpolator()} and used
+     *                           to calculate
+     *                           {@link WindowInsetsAnimationCompat#getInterpolatedFraction()}.
+     * @param cancellationSignal A cancellation signal that the caller can use to cancel the
+     *                           request to obtain control, or once they have control, to cancel
+     *                           the control.
+     * @param listener           The {@link WindowInsetsAnimationControlListener} that gets
+     *                           called when the windows are ready to be controlled, among other
+     *                           callbacks.
+     * @see WindowInsetsAnimationCompat#getFraction()
+     * @see WindowInsetsAnimationCompat#getInterpolatedFraction()
+     * @see WindowInsetsAnimationCompat#getInterpolator()
+     * @see WindowInsetsAnimationCompat#getDurationMillis()
+     */
+    public void controlWindowInsetsAnimation(@InsetsType int types, long durationMillis,
+                                             @Nullable Interpolator interpolator,
+                                             @Nullable CancellationSignal cancellationSignal,
+                                             @NonNull WindowInsetsAnimationControlListenerCompat listener) {
+        mImpl.controlWindowInsetsAnimation(types, durationMillis, interpolator, cancellationSignal,
+                listener);
+    }
+
+    /**
+     * Controls the behavior of system bars.
+     *
+     * @param behavior Determines how the bars behave when being hidden by the application.
+     * @see #getSystemBarsBehavior
+     */
+    public void setSystemBarsBehavior(@Behavior int behavior) {
+        mImpl.setSystemBarsBehavior(behavior);
+    }
+
+    /**
+     * Retrieves the requested behavior of system bars.
+     *
+     * @return the system bar behavior controlled by this window.
+     * @see #setSystemBarsBehavior(int)
+     */
+    @SuppressLint("WrongConstant")
+    @Behavior
+    public int getSystemBarsBehavior() {
+        return mImpl.getSystemBarsBehavior();
+    }
+
+    /**
+     * Adds a {@link WindowInsetsController.OnControllableInsetsChangedListener} to the window
+     * insets controller.
+     *
+     * @param listener The listener to add.
+     * @see OnControllableInsetsChangedListener
+     * @see #removeOnControllableInsetsChangedListener(
+     *OnControllableInsetsChangedListener)
+     */
+    public void addOnControllableInsetsChangedListener(
+            @NonNull OnControllableInsetsChangedListener listener) {
+        mImpl.addOnControllableInsetsChangedListener(listener);
+    }
+
+    /**
+     * Removes a {@link WindowInsetsController.OnControllableInsetsChangedListener} from the
+     * window insets controller.
+     *
+     * @param listener The listener to remove.
+     * @see WindowInsetsControllerCompat.OnControllableInsetsChangedListener
+     * @see #addOnControllableInsetsChangedListener(
+     *WindowInsetsControllerCompat.OnControllableInsetsChangedListener)
+     */
+    public void removeOnControllableInsetsChangedListener(
+            @NonNull WindowInsetsControllerCompat.OnControllableInsetsChangedListener
+                    listener) {
+        mImpl.removeOnControllableInsetsChangedListener(listener);
+    }
+
+    /**
+     * Listener to be notified when the set of controllable {@link WindowInsetsCompat.Type}
+     * controlled by a {@link WindowInsetsController} changes.
+     * <p>
+     * Once a {@link WindowInsetsCompat.Type} becomes controllable, the app will be able to
+     * control the window that is causing this type of insets by calling
+     * {@link #controlWindowInsetsAnimation}.
+     * <p>
+     * Note: When listening to cancellability of the {@link WindowInsets.Type#ime},
+     * {@link #controlWindowInsetsAnimation} may still fail in case the {@link InputMethodService}
+     * decides to cancel the show request. This could happen when there is a hardware keyboard
+     * attached.
+     *
+     * @see #addOnControllableInsetsChangedListener(
+     *OnControllableInsetsChangedListener)
+     * @see #removeOnControllableInsetsChangedListener(
+     *OnControllableInsetsChangedListener)
+     */
+    public interface OnControllableInsetsChangedListener {
+
+        /**
+         * Called when the set of controllable {@link WindowInsetsCompat.Type} changes.
+         *
+         * @param controller The controller for which the set of controllable
+         *                   {@link WindowInsetsCompat.Type}s
+         *                   are changing.
+         * @param typeMask   Bitwise behavior type-mask of the {@link WindowInsetsCompat.Type}s
+         *                   the controller is currently able to control.
+         */
+        void onControllableInsetsChanged(@NonNull WindowInsetsControllerCompat controller,
+                                         @InsetsType int typeMask);
+    }
+
+    private static class Impl {
+        @NonNull
+        protected final Window mWindow;
+
+        Impl(@NonNull final Window window) {
+            this.mWindow = window;
+        }
+
+        void show(int types) {
+            // No-op
+        }
+
+        void hide(int types) {
+            // No-op
+        }
+
+        void controlWindowInsetsAnimation(int types, long durationMillis, Interpolator interpolator,
+                                          CancellationSignal cancellationSignal,
+                                          WindowInsetsAnimationControlListenerCompat listener) {
+            // No-op
+        }
+
+        void setSystemBarsBehavior(int behavior) {
+            // No-op
+        }
+
+        int getSystemBarsBehavior() {
+            return 0;
+        }
+
+        public boolean isAppearanceLightStatusBars() {
+            return false;
+        }
+
+        public void setAppearanceLightStatusBars(boolean isLight) {
+            // No-op
+        }
+
+        public boolean isAppearanceLightNavigationBars() {
+            return false;
+        }
+
+        public void setAppearanceLightNavigationBars(boolean isLight) {
+            // No-op
+        }
+
+        void addOnControllableInsetsChangedListener(
+                @NonNull OnControllableInsetsChangedListener listener) {
+            // No-op
+        }
+
+        void removeOnControllableInsetsChangedListener(
+                @NonNull OnControllableInsetsChangedListener listener) {
+            // No-op
+        }
+
+        @SuppressWarnings("deprecation")
+        protected final void setSystemUiFlag(int systemUiFlag) {
+            View decorView = mWindow.getDecorView();
+            decorView.setSystemUiVisibility(decorView.getSystemUiVisibility() | systemUiFlag);
+        }
+
+        @SuppressWarnings("deprecation")
+        protected final void unsetSystemUiFlag(int systemUiFlag) {
+            View decorView = mWindow.getDecorView();
+            decorView.setSystemUiVisibility(decorView.getSystemUiVisibility() & ~systemUiFlag);
+        }
+    }
+
+    private static class Impl14 extends Impl {
+        @NonNull
+        private final View mView;
+
+        private static final int FIRST = 1;
+        protected static final int STATUS_BARS = FIRST;
+        private static final int NAVIGATION_BARS = 1 << 1;
+        private static final int IME = 1 << 3;
+        private static final int LAST = 1 << 8;
+
+        Impl14(@NonNull Window window, @NonNull View view) {
+            super(window);
+            mView = view;
+        }
+
+        @Override
+        void show(int typeMask) {
+            for (int i = FIRST; i <= LAST; i <<= 1) {
+                if ((typeMask & i) == 0) {
+                    continue;
+                }
+                showForType(i);
+            }
+        }
+
+        @SuppressWarnings("deprecation")
+        protected void showForType(int type) {
+            switch (type) {
+                case STATUS_BARS:
+                    unsetWindowFlag(WindowManager.LayoutParams.FLAG_FULLSCREEN);
+                    break;
+                case NAVIGATION_BARS:
+                    unsetSystemUiFlag(View.SYSTEM_UI_FLAG_HIDE_NAVIGATION);
+                    break;
+                case IME:
+                    // We'll try to find an available textView to focus to show the IME
+                    View view = mView;
+
+                    if (view.isInEditMode() || view.onCheckIsTextEditor()) {
+                        // The IME needs a text view to be focused to be shown
+                        // The view given to retrieve this controller is a textView so we can assume
+                        // that we can focus it in order to show the IME
+                        view.requestFocus();
+                    } else {
+                        view = mWindow.getCurrentFocus();
+                    }
+
+                    // Fallback on the container view
+                    if (view == null) {
+                        view = mWindow.findViewById(android.R.id.content);
+                    }
+
+                    if (view != null && view.hasWindowFocus()) {
+                        final View finalView = view;
+                        finalView.post(() -> ContextCompat.getSystemService(finalView.getContext(),
+                                        InputMethodManager.class).showSoftInput(finalView, 0));
+                    }
+            }
+        }
+
+        @Override
+        void hide(int typeMask) {
+            for (int i = FIRST; i <= LAST; i = i << 1) {
+                if ((typeMask & i) == 0) {
+                    continue;
+                }
+                hideForType(i);
+            }
+        }
+
+        @SuppressWarnings("deprecation")
+        protected void hideForType(int type) {
+            switch (type) {
+                case STATUS_BARS:
+                    setWindowFlag(WindowManager.LayoutParams.FLAG_FULLSCREEN);
+                    break;
+                case NAVIGATION_BARS:
+                    setSystemUiFlag(View.SYSTEM_UI_FLAG_HIDE_NAVIGATION);
+                    break;
+                case IME:
+                    ContextCompat.getSystemService(mWindow.getContext(), InputMethodManager.class)
+                            .hideSoftInputFromWindow(mWindow.getDecorView().getWindowToken(),
+                                    0);
+            }
+        }
+
+        protected final void setWindowFlag(int windowFlag) {
+            mWindow.addFlags(windowFlag);
+        }
+
+        protected final void unsetWindowFlag(int windowFlag) {
+            mWindow.clearFlags(windowFlag);
+        }
+    }
+
+    @RequiresApi(Build.VERSION_CODES.JELLY_BEAN)
+    private static class Impl16 extends Impl14 {
+        Impl16(@NonNull Window window, @NonNull View view) {
+            super(window, view);
+        }
+
+        @SuppressWarnings("deprecation")
+        @Override
+        protected void showForType(int type) {
+            if (type == STATUS_BARS) {
+                unsetSystemUiFlag(View.SYSTEM_UI_FLAG_FULLSCREEN);
+                unsetWindowFlag(WindowManager.LayoutParams.FLAG_FULLSCREEN);
+            } else {
+                super.showForType(type);
+            }
+        }
+
+        @SuppressWarnings("deprecation")
+        @Override
+        protected void hideForType(int type) {
+            if (type == STATUS_BARS) {
+                setSystemUiFlag(View.SYSTEM_UI_FLAG_FULLSCREEN);
+            } else {
+                super.hideForType(type);
+            }
+        }
+    }
+
+    @RequiresApi(Build.VERSION_CODES.KITKAT)
+    private static class Impl19 extends Impl16 {
+        Impl19(@NonNull Window window, @NonNull View view) {
+            super(window, view);
+        }
+
+        @SuppressWarnings("deprecation")
+        @Override
+        void setSystemBarsBehavior(int behavior) {
+            switch (behavior) {
+                case BEHAVIOR_SHOW_BARS_BY_SWIPE:
+                    unsetSystemUiFlag(View.SYSTEM_UI_FLAG_IMMERSIVE_STICKY);
+                    setSystemUiFlag(View.SYSTEM_UI_FLAG_IMMERSIVE);
+                    break;
+                case BEHAVIOR_SHOW_TRANSIENT_BARS_BY_SWIPE:
+                    unsetSystemUiFlag(View.SYSTEM_UI_FLAG_IMMERSIVE);
+                    setSystemUiFlag(View.SYSTEM_UI_FLAG_IMMERSIVE_STICKY);
+                    break;
+                case BEHAVIOR_SHOW_BARS_BY_TOUCH:
+                    unsetSystemUiFlag(View.SYSTEM_UI_FLAG_IMMERSIVE
+                            | View.SYSTEM_UI_FLAG_IMMERSIVE_STICKY);
+                    break;
+            }
+        }
+
+        @SuppressWarnings("deprecation")
+        @Override
+        int getSystemBarsBehavior() {
+            final int systemUiFlags = mWindow.getDecorView().getSystemUiVisibility();
+            if ((systemUiFlags & View.SYSTEM_UI_FLAG_IMMERSIVE_STICKY) != 0) {
+                return BEHAVIOR_SHOW_TRANSIENT_BARS_BY_SWIPE;
+            } else if ((systemUiFlags & View.SYSTEM_UI_FLAG_IMMERSIVE) != 0) {
+                return BEHAVIOR_SHOW_BARS_BY_SWIPE;
+            } else {
+                return BEHAVIOR_SHOW_BARS_BY_TOUCH;
+            }
+        }
+    }
+
+    @RequiresApi(Build.VERSION_CODES.M)
+    private static class Impl23 extends Impl19 {
+        Impl23(@NonNull Window window, @NonNull View view) {
+            super(window, view);
+        }
+
+        @SuppressWarnings("deprecation")
+        @Override
+        public boolean isAppearanceLightStatusBars() {
+            return (mWindow.getDecorView().getSystemUiVisibility()
+                    & View.SYSTEM_UI_FLAG_LIGHT_STATUS_BAR) != 0;
+        }
+
+        @SuppressWarnings("deprecation")
+        @Override
+        public void setAppearanceLightStatusBars(boolean isLight) {
+            if (isLight) {
+                unsetWindowFlag(WindowManager.LayoutParams.FLAG_TRANSLUCENT_STATUS);
+                setWindowFlag(WindowManager.LayoutParams.FLAG_DRAWS_SYSTEM_BAR_BACKGROUNDS);
+                setSystemUiFlag(View.SYSTEM_UI_FLAG_LIGHT_STATUS_BAR);
+            } else {
+                unsetSystemUiFlag(View.SYSTEM_UI_FLAG_LIGHT_STATUS_BAR);
+            }
+        }
+    }
+
+    @RequiresApi(Build.VERSION_CODES.O)
+    private static class Impl26 extends Impl23 {
+        Impl26(@NonNull Window window, @NonNull View view) {
+            super(window, view);
+        }
+
+        @SuppressWarnings("deprecation")
+        @Override
+        public boolean isAppearanceLightNavigationBars() {
+            return (mWindow.getDecorView().getSystemUiVisibility()
+                    & View.SYSTEM_UI_FLAG_LIGHT_NAVIGATION_BAR) != 0;
+        }
+
+        @SuppressWarnings("deprecation")
+        @Override
+        public void setAppearanceLightNavigationBars(boolean isLight) {
+            if (isLight) {
+                unsetWindowFlag(WindowManager.LayoutParams.FLAG_TRANSLUCENT_NAVIGATION);
+                setWindowFlag(WindowManager.LayoutParams.FLAG_DRAWS_SYSTEM_BAR_BACKGROUNDS);
+                setSystemUiFlag(View.SYSTEM_UI_FLAG_LIGHT_NAVIGATION_BAR);
+            } else {
+                unsetSystemUiFlag(View.SYSTEM_UI_FLAG_LIGHT_NAVIGATION_BAR);
+            }
+        }
+    }
+
+    @RequiresApi(Build.VERSION_CODES.R)
+    private static class Impl30 extends Impl {
+        final WindowInsetsControllerCompat mCompatController;
+        final WindowInsetsController mInsetsController;
+        private final SimpleArrayMap<
+                WindowInsetsControllerCompat.OnControllableInsetsChangedListener,
+                WindowInsetsController.OnControllableInsetsChangedListener>
+                mListeners = new SimpleArrayMap<>();
+
+        Impl30(@NonNull Window window, @NonNull WindowInsetsControllerCompat compatController) {
+            super(window);
+            mInsetsController = window.getInsetsController();
+            mCompatController = compatController;
+        }
+
+        @Override
+        void show(@InsetsType int types) {
+            if ((types & WindowInsetsCompat.Type.ime()) != 0
+                    && Build.VERSION.SDK_INT < 32) {
+                // This is a strange-looking workaround by making a call and ignoring the result.
+                // We don't use the return value here, but isActive() has the side-effect of
+                // calling a hidden method checkFocus(), which ensures that the IME state has the
+                // correct view in some situations (especially when the focused view changes).
+                // This is essentially a backport, since an equivalent checkFocus() call was
+                // added in API 32 to improve behavior:
+                // https://issuetracker.google.com/issues/189858204
+                mWindow.getContext().getSystemService(InputMethodManager.class).isActive();
+            }
+            mInsetsController.show(types);
+        }
+
+        @Override
+        void hide(@InsetsType int types) {
+            mInsetsController.hide(types);
+        }
+
+        @Override
+        public boolean isAppearanceLightStatusBars() {
+            return (mInsetsController.getSystemBarsAppearance()
+                    & WindowInsetsController.APPEARANCE_LIGHT_STATUS_BARS) != 0;
+        }
+
+        @SuppressWarnings("deprecation")
+        @Override
+        public void setAppearanceLightStatusBars(boolean isLight) {
+            if (isLight) {
+                setSystemUiFlag(View.SYSTEM_UI_FLAG_LIGHT_STATUS_BAR);
+                mInsetsController.setSystemBarsAppearance(
+                        WindowInsetsController.APPEARANCE_LIGHT_STATUS_BARS,
+                        WindowInsetsController.APPEARANCE_LIGHT_STATUS_BARS);
+            } else {
+                unsetSystemUiFlag(View.SYSTEM_UI_FLAG_LIGHT_STATUS_BAR);
+                mInsetsController.setSystemBarsAppearance(
+                        0,
+                        WindowInsetsController.APPEARANCE_LIGHT_STATUS_BARS);
+            }
+        }
+
+        @Override
+        public boolean isAppearanceLightNavigationBars() {
+            return (mInsetsController.getSystemBarsAppearance()
+                    & WindowInsetsController.APPEARANCE_LIGHT_NAVIGATION_BARS) != 0;
+        }
+
+        @SuppressWarnings("deprecation")
+        @Override
+        public void setAppearanceLightNavigationBars(boolean isLight) {
+            if (isLight) {
+                setSystemUiFlag(View.SYSTEM_UI_FLAG_LIGHT_NAVIGATION_BAR);
+                mInsetsController.setSystemBarsAppearance(
+                        WindowInsetsController.APPEARANCE_LIGHT_NAVIGATION_BARS,
+                        WindowInsetsController.APPEARANCE_LIGHT_NAVIGATION_BARS);
+            } else {
+                unsetSystemUiFlag(View.SYSTEM_UI_FLAG_LIGHT_NAVIGATION_BAR);
+                mInsetsController.setSystemBarsAppearance(
+                        0,
+                        WindowInsetsController.APPEARANCE_LIGHT_NAVIGATION_BARS);
+            }
+        }
+
+        @Override
+        void controlWindowInsetsAnimation(@InsetsType int types, long durationMillis,
+                                          @Nullable Interpolator interpolator,
+                                          @Nullable CancellationSignal cancellationSignal,
+                                          @NonNull final WindowInsetsAnimationControlListenerCompat listener) {
+            WindowInsetsAnimationControlListener fwListener =
+                    new WindowInsetsAnimationControlListener() {
+                        private WindowInsetsAnimationControllerCompat mCompatAnimController = null;
+
+                        @Override
+                        public void onReady(@NonNull WindowInsetsAnimationController controller,
+                                            int types) {
+                            mCompatAnimController =
+                                    new WindowInsetsAnimationControllerCompat(controller);
+                            listener.onReady(mCompatAnimController, types);
+                        }
+
+                        @Override
+                        public void onFinished(
+                                @NonNull WindowInsetsAnimationController controller) {
+                            listener.onFinished(mCompatAnimController);
+                        }
+
+                        @Override
+                        public void onCancelled(
+                                @Nullable WindowInsetsAnimationController controller) {
+                            listener.onCancelled(controller == null ? null : mCompatAnimController);
+                        }
+                    };
+
+            final android.os.CancellationSignal platformSignal = cancellationSignal != null
+                    ? (android.os.CancellationSignal) cancellationSignal.getCancellationSignalObject()
+                    : null;
+            mInsetsController.controlWindowInsetsAnimation(types, durationMillis, interpolator,
+                    platformSignal, fwListener);
+        }
+
+        /**
+         * Controls the behavior of system bars.
+         *
+         * @param behavior Determines how the bars behave when being hidden by the application.
+         * @see #getSystemBarsBehavior
+         */
+        @Override
+        void setSystemBarsBehavior(@Behavior int behavior) {
+            mInsetsController.setSystemBarsBehavior(behavior);
+        }
+
+        /**
+         * Retrieves the requested behavior of system bars.
+         *
+         * @return the system bar behavior controlled by this window.
+         * @see #setSystemBarsBehavior(int)
+         */
+        @SuppressLint("WrongConstant")
+        @Override
+        @Behavior
+        int getSystemBarsBehavior() {
+            return mInsetsController.getSystemBarsBehavior();
+        }
+
+        @Override
+        void addOnControllableInsetsChangedListener(
+                @NonNull final WindowInsetsControllerCompat.OnControllableInsetsChangedListener
+                        listener) {
+
+            if (mListeners.containsKey(listener)) {
+                // The listener has already been added.
+                return;
+            }
+            WindowInsetsController.OnControllableInsetsChangedListener
+                    fwListener = (controller, typeMask) -> {
+                if (mInsetsController == controller) {
+                    listener.onControllableInsetsChanged(
+                            mCompatController, typeMask);
+                }
+            };
+            mListeners.put(listener, fwListener);
+            mInsetsController.addOnControllableInsetsChangedListener(fwListener);
+        }
+
+        @Override
+        void removeOnControllableInsetsChangedListener(
+                @NonNull WindowInsetsControllerCompat.OnControllableInsetsChangedListener
+                        listener) {
+            WindowInsetsController.OnControllableInsetsChangedListener
+                    fwListener = mListeners.remove(listener);
+            if (fwListener != null) {
+                mInsetsController.removeOnControllableInsetsChangedListener(fwListener);
+            }
+        }
+    }
+}


### PR DESCRIPTION
The system UI flags have been deprecated in favor of using `WindowInsetsController` instead.

*Note:* I will transition from draft after checking on older Android versions.