### PR TITLE
Remove command obsolete in Java17

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -13,7 +13,7 @@
 #Tue Feb 04 16:31:15 EET 2020
 android.enableJetifier=false
 #org.gradle.jvmargs=-Xmx2024M -Dkotlin.daemon.jvm.options\="-Xmx2024M"
-org.gradle.jvmargs=-Xmx4g -XX:MaxPermSize=4g -XX:+HeapDumpOnOutOfMemoryError -Dfile.encoding=UTF-8
+org.gradle.jvmargs=-Xmx4g -XX:+HeapDumpOnOutOfMemoryError -Dfile.encoding=UTF-8
 
 android.useAndroidX=true
 android.debug.obsoleteApi=true


### PR DESCRIPTION
AGP8: https://github.com/foobnix/LibreraReader/commit/85fcb1a6e3f82664192a240a9fdbb7b8fb9bd1cc#diff-49a96e7eea8a94af862798a45174e6ac43eb4f8b4bd40759b5da63ba31ec3ef7R12

Needs Java17: https://gitlab.com/fdroid/fdroiddata/-/jobs/4153237459#L999

Which does not know about `MaxPermSize` any more: https://gitlab.com/fdroid/fdroiddata/-/jobs/4170899900#L744

Fixed in F-Droid directly: https://gitlab.com/fdroid/fdroiddata/-/commit/9a8f02d30735ab2141686de8bf064d5af9a271e0