### PR TITLE
small nitpick in italian translation

### DIFF
--- a/app/src/main/res/values-it/strings.xml
+++ b/app/src/main/res/values-it/strings.xml
@@ -55,7 +55,7 @@
    <string name="product">Prodotto</string>
    <string name="version">Versione</string>
    <string name="licence_gnu_gpl_v3_0">Licenza: GNU GPL v3.0</string>
-   <string name="licenses_for_libraries">Licenze per le biblioteche</string>
+   <string name="licenses_for_libraries">Licenze per le librerie</string>
    <string name="autor_ivan_ivanenko">Autore: Ivan Ivanenko</string>
    <string name="support">Supporto</string>
    <string name="web">Web</string>


### PR DESCRIPTION
in a programming context "libraries" of code are translated as "librerie" and not "biblioteche" which are the ones that lend books