### PR TITLE
Allowing for search for a single kanji, fixes #645

### DIFF
--- a/app/src/main/java/com/foobnix/pdf/info/view/DragingDialogs.java
+++ b/app/src/main/java/com/foobnix/pdf/info/view/DragingDialogs.java
@@ -1572,9 +1572,15 @@ public class DragingDialogs {
                             return;
                         }
                         String searchString = searchEdit.getText().toString().trim();
-                        if (searchString.length() < 2) {
-                            Toast.makeText(controller.getActivity(), R.string.please_enter_more_characters_to_search, Toast.LENGTH_SHORT).show();
-                            return;
+                        int l=searchString.length();
+                        char c ='0'; // never allowed as a single search character
+                        if ( l == 1) c=searchString.charAt(0);
+                        // Allow Kanji/Hanzi as single search character. Other type of
+                        // characters may be added.
+                        if ( l < 2 && (c > '\u9FFF' || c < '\u4E00'))
+                        {
+                                Toast.makeText(controller.getActivity(), R.string.please_enter_more_characters_to_search, Toast.LENGTH_SHORT).show();
+                                return;
                         }
                         lastSearchText = searchString;
                         TempHolder.isSeaching = true;


### PR DESCRIPTION
Added exception to the restriction of the length of a search string being > 2 as long as this character is in the kanji area (unicode 0x4e00-0x9fff).
Maybe other unicode areas should be added. (e.g. kanji radicals, other languages with comparable features).

For a single kanji search it would be useful only to highlight this single character not the whole "word" as there are usually no blank spaces between words in chinese or japanese, so at the moment you get a whole line highlighted.

fixes #645 