### PR TITLE
Add previousLibraryMode setting to AppState and use it in SearchFragment2

### DIFF
--- a/app/src/main/java/com/foobnix/model/AppState.java
+++ b/app/src/main/java/com/foobnix/model/AppState.java
@@ -504,6 +504,7 @@ public class AppState {
     public String toLang = Urls.getLangCode();
     @IgnoreHashCode
     public int orientation = ActivityInfo.SCREEN_ORIENTATION_SENSOR;
+    public int previousLibraryMode = MODE_GRID;
     public int libraryMode = MODE_GRID;
     public int broseMode = MODE_LIST;
     public int recentMode = MODE_LIST;

--- a/app/src/main/java/com/foobnix/ui2/fragment/SearchFragment2.java
+++ b/app/src/main/java/com/foobnix/ui2/fragment/SearchFragment2.java
@@ -103,7 +103,6 @@ public class SearchFragment2 extends UIFragment<FileMeta> {
     public static int NONE = -1;
     public static List<FileMeta> cacheItems;
     final Set<String> autocomplitions = new HashSet<String>();
-    public int prevLibModeFileMeta = AppState.MODE_GRID;
     public int prevLibModeAuthors = NONE;
     public int rememberPos = 0;
     FileMetaAdapter searchAdapter;
@@ -643,7 +642,7 @@ public class SearchFragment2 extends UIFragment<FileMeta> {
         }
 
         searchEditText.setText(mode.getDotPrefix() + " " + result);
-        AppState.get().libraryMode = prevLibModeFileMeta;
+        AppState.get().libraryMode = AppState.get().previousLibraryMode;
         onGridList();
         searchAndOrderAsync();
     }
@@ -892,7 +891,7 @@ public class SearchFragment2 extends UIFragment<FileMeta> {
         }
 
         if (Arrays.asList(AppState.MODE_GRID, AppState.MODE_COVERS, AppState.MODE_LIST, AppState.MODE_LIST_COMPACT).contains(AppState.get().libraryMode)) {
-            prevLibModeFileMeta = AppState.get().libraryMode;
+            AppState.get().previousLibraryMode = AppState.get().libraryMode;
             searchEditText.setEnabled(true);
             sortBy.setEnabled(true);
             sortOrder.setEnabled(true);
@@ -1126,7 +1125,7 @@ public class SearchFragment2 extends UIFragment<FileMeta> {
 
             searchEditText.setText("");
             if (prevLibModeAuthors == NONE) {
-                prevLibModeAuthors = prevLibModeFileMeta;
+                prevLibModeAuthors = AppState.get().previousLibraryMode;
             }
             AppState.get().libraryMode = prevLibModeAuthors;
             onGridList();
@@ -1134,7 +1133,7 @@ public class SearchFragment2 extends UIFragment<FileMeta> {
             return true;
 
         } else {
-            AppState.get().libraryMode = prevLibModeFileMeta;
+            AppState.get().libraryMode = AppState.get().previousLibraryMode;
             onGridList();
             searchAndOrderAsync();
             return true;


### PR DESCRIPTION
This patch fixes the following behavior, before this patch, the behavior was as follows:
1) enable 'Restore search query on startup' and select List as viewing mode
2) go to Series
3) close the app
4) re-open the app
5) click on a series from the list
6) grid mode is selected as the viewing mode

With this patch, it restores the viewing mode correctly when at step 6.