### PR TITLE
Fix translation mistake in german translation of "open books on page 1" setting

### DIFF
--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -664,5 +664,5 @@
    <string name="ad_privacy_settings">Datenschutzeinstellungen für Anzeigen</string>
    <string name="allow_other_music_to_play">Andere Musik abspielen lassen</string>
    <string name="enable_image_scale">Bildskalierung aktivieren</string>
-   <string name="open_books_on_page_1">Offene Bücher auf Seite 1</string>
+   <string name="open_books_on_page_1">Bücher auf Seite 1 öffnen</string>
 </resources>


### PR DESCRIPTION
seems someone made a small mistake with the translation and read the "open" as an adjective, instead of a verb
so the setting currently talks about books that are open, instead of the act opening books on page 1
so I changed it