### PR TITLE
Fix status bar transparency

### DIFF
--- a/app/src/main/res/values-v21/styles.xml
+++ b/app/src/main/res/values-v21/styles.xml
@@ -4,13 +4,11 @@
     <style name="StyledIndicatorsWhite" parent="@android:style/Theme.Material.Light.NoActionBar">
         <item name="android:windowNoTitle">true</item>
         <item name="android:windowDisablePreview">true</item>
-        <item name="android:windowIsTranslucent">true</item>
     </style>
 
     <style name="StyledIndicatorsBlack" parent="@android:style/Theme.Material.NoActionBar">
         <item name="android:windowNoTitle">true</item>
         <item name="android:windowDisablePreview">true</item>
-        <item name="android:windowIsTranslucent">true</item>
     </style>
 
 </resources>

--- a/app/src/main/res/values-v29/styles.xml
+++ b/app/src/main/res/values-v29/styles.xml
@@ -4,13 +4,11 @@
     <style name="StyledIndicatorsWhite" parent="Theme.AppCompat.Light">
         <item name="android:windowNoTitle">true</item>
         <item name="android:windowDisablePreview">true</item>
-        <item name="android:windowIsTranslucent">true</item>
     </style>
 
     <style name="StyledIndicatorsBlack" parent="Theme.AppCompat.NoActionBar">
         <item name="android:windowNoTitle">true</item>
         <item name="android:windowDisablePreview">true</item>
-        <item name="android:windowIsTranslucent">true</item>
     </style>
 
 </resources>


### PR DESCRIPTION
This change fixes a visual issue similar to the one described in issue #1211. A transparent gap appeared at the side of the screen in normal and fullscreen modes when the device was in horizontal orientation. Unfortunately, I wasn't able to reproduce the issue in an emulator, only on my own physical device.

My device details:
* Model: Xiaomi 11 Lite
* Android version: 14 UKQ1.240624.001

The issue was resolved by removing android:windowIsTranslucent from the theme files.

Before patch:
![before](https://github.com/user-attachments/assets/e614d7e7-8a02-4fdf-9222-5d1aa9504223)

After patch:
![after](https://github.com/user-attachments/assets/02748731-a7af-45de-97d7-e64021e9fefd)