### PR TITLE
Fix font color picker incorrectly updating the foreground color

### DIFF
--- a/app/src/main/java/com/foobnix/pdf/info/widget/ColorsDialog.java
+++ b/app/src/main/java/com/foobnix/pdf/info/widget/ColorsDialog.java
@@ -302,7 +302,7 @@ public class ColorsDialog {
                     @Override
                     public void onClick(View v) {
                         try {
-                            colorForegroundChoose = Color.parseColor(input.getText().toString());
+                            colorTextChoose = Color.parseColor(input.getText().toString());
                             updateAll(colorTextChoose, colorBgChoose, colorForegroundChoose);
                             dialog.dismiss();
                         } catch (Exception e) {


### PR DESCRIPTION
It seems that the font color picker dialog was incorrectly updating the foreground color in this commit https://github.com/foobnix/LibreraReader/commit/09af513a00f77f2faf09196e49db2e0faa15c3ab

Note: I did not test/build this fix

closes #1497