### PR TITLE
Increase the bookmark screen max lines length to 10

### DIFF
--- a/app/src/main/java/com/foobnix/pdf/info/presentation/BookmarksAdapter.java
+++ b/app/src/main/java/com/foobnix/pdf/info/presentation/BookmarksAdapter.java
@@ -55,6 +55,8 @@ public class BookmarksAdapter extends BaseAdapter {
         final AppBookmark bookmark = objects.get(position);
 
         final TextView textView = (TextView) view.findViewById(R.id.text);
+        textView.setMaxLines(muxnumberOfLines);
+        textView.setEllipsize(android.text.TextUtils.TruncateAt.END);
         final TextView pageView = (TextView) view.findViewById(R.id.page);
         final TextView titleView = (TextView) view.findViewById(R.id.title);
         final ImageView image = (ImageView) view.findViewById(R.id.image);

--- a/app/src/main/res/layout/bookmark_item.xml
+++ b/app/src/main/res/layout/bookmark_item.xml
@@ -112,7 +112,7 @@
                     android:ellipsize="end"
                     android:layout_weight="1"
                     android:gravity="center_vertical"
-                    android:maxLines="3"
+                    android:maxLines="10"
                     android:text="Bookmark text   Bookmark text BookmarkBookmark text BookmarkBookmark text BookmarkBookmark text BookmarkBookmark text Bookmark" />
 
                 <ImageView


### PR DESCRIPTION
No idea if you even like this change, but I figured out a possible solution. This should increase the bookmark contents max length to 10 lines, while keeping the 3 lines limit in the bookmarks dialog (inside the book),

To test:
- check the Bookmarks tab in the main menu (next to FOLDER/FAVORITES/LIBRARY/RECENT) – long bookmarks should draw up to 10 lines, compared to previous limit of three
- load any book with bookmarks and open the Bookmarks dialog; these bookmarks should show up to three lines like before – it was tied to the bookmark_item.xml so I had to override it programatically

If you like, you can just make it 10 lines for both views and accept only the maxLines value in the bookmark_item.xml. This change will improve the bookmark experience, as these are too basic now and would require you so much work and time to rewrite from scratch. With this change (pls test it yourself), users could at least see the bigger context of the fragments they wanted to keep. Cheers.

Closes https://github.com/foobnix/LibreraReader/issues/1512