### PR TITLE
Add option to remove slider and back on press of slider

### DIFF
--- a/app/src/main/java/com/foobnix/model/AppState.java
+++ b/app/src/main/java/com/foobnix/model/AppState.java
@@ -349,6 +349,7 @@ public class AppState {
     public boolean isShowPanelBookNameScrollMode = true;
     public boolean isShowPanelBookNameBookMode = false;
     public boolean isShowReadingProgress = true;
+    public boolean isShowBottomSeekBar = true;
     public boolean isShowChaptersOnProgress = true;
     public boolean isShowSubChaptersOnProgress = true;
     public int antiAliasLevel = 8;//0-8

--- a/app/src/main/java/com/foobnix/pdf/info/view/DragingDialogs.java
+++ b/app/src/main/java/com/foobnix/pdf/info/view/DragingDialogs.java
@@ -3295,6 +3295,7 @@ public class DragingDialogs {
                 View inflate = inflater.inflate(R.layout.dialog_status_bar_settings, null, false);
 
                 final CheckBox isShowReadingProgress = inflate.findViewById(R.id.isShowReadingProgress);
+                final CheckBox isShowBottomSeekBar = inflate.findViewById(R.id.isShowBottomSeekBar);
                 final CheckBox isShowChaptersOnProgress = inflate.findViewById(R.id.isShowChaptersOnProgress);
                 final CheckBox isShowSubChaptersOnProgress = inflate.findViewById(R.id.isShowSubChaptersOnProgress);
 
@@ -3312,6 +3313,16 @@ public class DragingDialogs {
                         isShowSubChaptersOnProgress.setEnabled(isChecked);
                         if (!isChecked) {
                             isShowSubChaptersOnProgress.setChecked(isChecked);
+                        }
+                    }
+                });
+
+                isShowBottomSeekBar.setChecked(AppState.get().isShowBottomSeekBar);
+                isShowBottomSeekBar.setOnCheckedChangeListener(new OnCheckedChangeListener() {
+                    @Override public void onCheckedChanged(CompoundButton buttonView, boolean isChecked) {
+                        AppState.get().isShowBottomSeekBar = isChecked;
+                        if (onRefresh != null) {
+                            onRefresh.run();
                         }
                     }
                 });

--- a/app/src/main/java/com/foobnix/pdf/info/wrapper/DocumentWrapperUI.java
+++ b/app/src/main/java/com/foobnix/pdf/info/wrapper/DocumentWrapperUI.java
@@ -238,7 +238,7 @@ public class DocumentWrapperUI {
             batteryIcon, fullscreen, onTextReplacement;
     ImageView showSearch, nextScreenType, moveCenter, autoScroll, textToSpeach, onModeChange, imageMenuArrow, editTop2,
             goToPage1, goToPage1Top;
-    View  titleBar, overlay, menuLayout, moveLeft, moveRight, bottomBar, onCloseBook, seekSpeedLayot, zoomPlus,
+    View  titleBar, overlay, menuLayout, moveLeft, moveRight, bottomBar, seekLine, onCloseBook, seekSpeedLayot, zoomPlus,
             zoomMinus;
     public View.OnLongClickListener onCloseLongClick = new View.OnLongClickListener() {
 
@@ -335,11 +335,10 @@ public class DocumentWrapperUI {
 
         @Override
         public void onProgressChanged(final SeekBar seekBar, final int progress, final boolean fromUser) {
-
-            dc.onGoToPage(progress + 1);
-
+            if (fromUser) {
+                dc.onGoToPage(progress + 1);
+            }
             Apps.accessibilityText(a, a.getString(R.string.m_current_page) + " " + dc.getCurentPageFirst1());
-            //updateUI();
         }
     };
     public View.OnClickListener onShowHideEditPanel = new View.OnClickListener() {
@@ -1231,6 +1230,7 @@ public class DocumentWrapperUI {
         pagesCountIndicator.setVisibility(View.GONE);
 
         currentSeek = (TextView) a.findViewById(R.id.currentSeek);
+        seekLine = a.findViewById(R.id.seekLine);
         maxSeek = (TextView) a.findViewById(R.id.maxSeek);
         bookName = (TextView) a.findViewById(R.id.bookName);
 
@@ -1803,6 +1803,7 @@ public class DocumentWrapperUI {
         updateLock();
 
         bottomBar.setVisibility(View.VISIBLE);
+        seekLine.setVisibility(AppState.get().isShowBottomSeekBar ? View.VISIBLE : View.GONE);
         //adFrame.setVisibility(View.VISIBLE);
         // adFrame.setClickable(true);
         // adFrame.setTag(null);

--- a/app/src/main/java/com/foobnix/pdf/info/wrapper/DocumentWrapperUI.java
+++ b/app/src/main/java/com/foobnix/pdf/info/wrapper/DocumentWrapperUI.java
@@ -327,10 +327,12 @@ public class DocumentWrapperUI {
 
         @Override
         public void onStopTrackingTouch(final SeekBar seekBar) {
+            showHideHistory();
         }
 
         @Override
         public void onStartTrackingTouch(final SeekBar seekBar) {
+            dc.getLinkHistory().add(dc.getCurentPageFirst1());
         }
 
         @Override
@@ -1796,6 +1798,7 @@ public class DocumentWrapperUI {
     };
 
     public void show() {
+        showHideHistory();
         menuLayout.setVisibility(View.VISIBLE);
 
         titleBar.setVisibility(View.VISIBLE);

--- a/app/src/main/java/com/foobnix/pdf/search/activity/HorizontalViewActivity.java
+++ b/app/src/main/java/com/foobnix/pdf/search/activity/HorizontalViewActivity.java
@@ -2510,10 +2510,12 @@ public class HorizontalViewActivity extends AdsFragmentActivity {
 
         @Override
         public void onStopTrackingTouch(final SeekBar seekBar) {
+            showHideHistory();
         }
 
         @Override
         public void onStartTrackingTouch(final SeekBar seekBar) {
+            dc.getLinkHistory().add(dc.getCurentPageFirst1());
         }
 
         @Override

--- a/app/src/main/java/com/foobnix/pdf/search/activity/HorizontalViewActivity.java
+++ b/app/src/main/java/com/foobnix/pdf/search/activity/HorizontalViewActivity.java
@@ -142,6 +142,7 @@ public class HorizontalViewActivity extends AdsFragmentActivity {
     volatile Boolean isInitPosistion = null;
     volatile int isInitOrientation;
     ProgressDraw progressDraw;
+    View seekLine;
     LinearLayout pageshelper;
     String quickBookmark;
     ClickUtils clickUtils;
@@ -407,6 +408,7 @@ public class HorizontalViewActivity extends AdsFragmentActivity {
         moveCenter = findViewById(R.id.moveCenter);
 
         currentSeek = (TextView) findViewById(R.id.currentSeek);
+        seekLine = findViewById(R.id.seekLine);
         maxSeek = (TextView) findViewById(R.id.maxSeek);
 
         toastBrightnessText = (TextView) findViewById(R.id.toastBrightnessText);
@@ -2091,6 +2093,10 @@ public class HorizontalViewActivity extends AdsFragmentActivity {
         updateBannnerTop();
         showPagesHelper();
 
+        if (seekLine != null) {
+            seekLine.setVisibility(AppState.get().isEditMode && AppState.get().isShowBottomSeekBar ? View.VISIBLE : View.GONE);
+        }
+
         if (prev == AppState.get().isEditMode) {
             return;
         }
@@ -2103,6 +2109,9 @@ public class HorizontalViewActivity extends AdsFragmentActivity {
         if (!animated || AppState.get().appTheme == AppState.THEME_INK) {
             actionBar.setVisibility(AppState.get().isEditMode ? View.VISIBLE : View.GONE);
             bottomBar.setVisibility(AppState.get().isEditMode ? View.VISIBLE : View.GONE);
+            if (seekLine != null) {
+                seekLine.setVisibility(AppState.get().isEditMode && AppState.get().isShowBottomSeekBar ? View.VISIBLE : View.GONE);
+            }
             //adFrame.setVisibility(AppState.get().isEditMode ? View.VISIBLE : View.GONE);
 
             DocumentController.chooseFullScreen(this, AppState.get().fullScreenMode);
@@ -2144,6 +2153,9 @@ public class HorizontalViewActivity extends AdsFragmentActivity {
                     try {
                         actionBar.setVisibility(View.VISIBLE);
                         bottomBar.setVisibility(View.VISIBLE);
+                        if (seekLine != null) {
+                            seekLine.setVisibility(AppState.get().isShowBottomSeekBar ? View.VISIBLE : View.GONE);
+                        }
                         //adFrame.setVisibility(View.VISIBLE);
                         ///adFrame.setTag(null);
 

--- a/app/src/main/res/layout/dialog_status_bar_settings.xml
+++ b/app/src/main/res/layout/dialog_status_bar_settings.xml
@@ -48,6 +48,13 @@
             android:text="@string/show_book_title" />
 
         <CheckBox
+            android:id="@+id/isShowBottomSeekBar"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_marginLeft="10dip"
+            android:text="@string/show_reading_slider" />
+
+        <CheckBox
             android:id="@+id/isShowReadingProgress"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"

--- a/app/src/main/res/layout/document_footer.xml
+++ b/app/src/main/res/layout/document_footer.xml
@@ -164,6 +164,7 @@
         </LinearLayout>
 
         <LinearLayout
+			android:id="@+id/seekLine"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
             android:clickable="true"

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -137,6 +137,7 @@
    <string name="status_bar">Status Bar</string>
    <string name="show_status_bar">Show status bar</string>
    <string name="show_progress_of_reading">Enable progress bar</string>
+    <string name="show_reading_slider">Show progress slider</string>
    <string name="enable_rewind_of_pages_using_the_read_progress_line">Navigate by sliding across status bar</string>
    <string name="text_size">Font size</string>
    <string name="line_height">Progress bar height</string>


### PR DESCRIPTION
Closes issue #1504

This addresses the issues highlighted in issue #1504. Options 1 and 4 are implemented:
1. Either allow to remove this slider in the option

4. Or add a "get back to previous page flip position" button (where you can click onto to get to the last read page). This could be a dynamic bookmark that's changing after each page flipped while reading.

The seek slider bar at the bottom can be removed in the "Status Bar" settings. 

Whenever the slider bar is clicked, a history is created that allows user to click the back button on the toolbar to go back to the previous location.