### PR TITLE
Enhance text replacement

### DIFF
--- a/app/src/main/java/com/foobnix/ext/Fb2Extractor.java
+++ b/app/src/main/java/com/foobnix/ext/Fb2Extractor.java
@@ -172,7 +172,7 @@ public class Fb2Extractor extends BaseExtractor {
 
         while ((line = input.readLine()) != null) {
             if (TempHolder.get().loadingCancelled.get()) {
-               return;
+                return;
             }
             if (!isValidXMLChecked && line.length() == 0) {
                 continue;
@@ -292,11 +292,11 @@ public class Fb2Extractor extends BaseExtractor {
 
             }
 
-
-            boolean isProcess = AppState.get().isEnableTextReplacement ||
-                    (BookCSS.get().isAutoHypens && TxtUtils.isNotEmpty(AppSP.get().hypenLang));
-            if (isProcess) {
-                line = HypenUtils.applyHypnes(line, replacements);
+            if (AppState.get().isEnableTextReplacement) {
+                line = HypenUtils.applyTextReplacements(line, replacements);
+            }
+            if (BookCSS.get().isAutoHypens && TxtUtils.isNotEmpty(AppSP.get().hypenLang)) {
+                line = HypenUtils.applyHyphens(line);
             }
 
             if (!isValidXML) {
@@ -483,7 +483,6 @@ public class Fb2Extractor extends BaseExtractor {
         }
         return NCX.replace("%nav%", navs.toString());
     }
-
 
 
     public static List<String> getFb2Titles(String fb2, String encoding) throws Exception {
@@ -728,7 +727,7 @@ public class Fb2Extractor extends BaseExtractor {
         byte[] decode = null;
         try {
             XmlPullParser xpp = XmlParser.buildPullParser();
-            try(final FileInputStream inputStream = new FileInputStream(path)) {
+            try (final FileInputStream inputStream = new FileInputStream(path)) {
                 xpp.setInput(inputStream, "UTF-8");
 
                 int eventType = xpp.getEventType();
@@ -747,7 +746,7 @@ public class Fb2Extractor extends BaseExtractor {
                             if (imageCover == null) {
                                 imageCover = xpp.getAttributeValue(0);
                                 if (TxtUtils.isNotEmpty(imageCover) && imageCover.toLowerCase(Locale.US)
-                                                                                 .contains("cover")) {
+                                        .contains("cover")) {
                                     imageCover = imageID = imageCover.replace("#", "");
                                 } else {
                                     imageCover = null;
@@ -756,7 +755,7 @@ public class Fb2Extractor extends BaseExtractor {
                         }
 
                         if (imageID != null && xpp.getName()
-                                                  .equals("binary") && imageID.equals(xpp.getAttributeValue(null, "id"))) {
+                                .equals("binary") && imageID.equals(xpp.getAttributeValue(null, "id"))) {
                             String text = xpp.nextText();
                             if (text != null) {
                                 decode = Base64.decode(text, Base64.DEFAULT);
@@ -1197,10 +1196,11 @@ public class Fb2Extractor extends BaseExtractor {
                 }
 
                 if (!isFindBodyEnd) {
-                    boolean isProcess = AppState.get().isEnableTextReplacement ||
-                            (BookCSS.get().isAutoHypens && TxtUtils.isNotEmpty(AppSP.get().hypenLang));
-                    if (isProcess) {
-                        line = HypenUtils.applyHypnes(line, replacements);
+                    if (AppState.get().isEnableTextReplacement) {
+                        line = HypenUtils.applyTextReplacements(line, replacements);
+                    }
+                    if (BookCSS.get().isAutoHypens && TxtUtils.isNotEmpty(AppSP.get().hypenLang)) {
+                        line = HypenUtils.applyHyphens(line);
                     }
                 }
                 writer.print(line);

--- a/app/src/main/java/com/foobnix/ext/HtmlExtractor.java
+++ b/app/src/main/java/com/foobnix/ext/HtmlExtractor.java
@@ -138,13 +138,17 @@ public class HtmlExtractor {
                 string = html.toString();
             }
 
-            if (AppState.get().isEnableTextReplacement || (BookCSS.get().isAutoHypens && TxtUtils.isNotEmpty(AppSP.get().hypenLang))) {
+            boolean needsTextReplacement = AppState.get().isEnableTextReplacement;
+            boolean needsHyphens = BookCSS.get().isAutoHypens && TxtUtils.isNotEmpty(AppSP.get().hypenLang);
+            if (needsTextReplacement || needsHyphens) {
                 HypenUtils.applyLanguage(AppSP.get().hypenLang);
                 int bodyInt = string.indexOf("<body");
                 bodyInt = string.indexOf(">", bodyInt);
 
-                String processedString = HypenUtils.applyTextReplacements(string.substring(bodyInt), AppData.get().getAllTextReplaces(), AppState.get().isEnableTextReplacement);
-                processedString = HypenUtils.applyHyphens(processedString);
+                String processedString = HypenUtils.applyTextReplacements(string.substring(bodyInt), AppData.get().getAllTextReplaces(), needsTextReplacement);
+                if (needsHyphens) {
+                    processedString = HypenUtils.applyHyphens(processedString);
+                }
                 string = string.substring(0, bodyInt) + processedString;
                 // string = Jsoup.clean(string, Whitelist.none());
             }

--- a/app/src/main/java/com/foobnix/ext/HtmlExtractor.java
+++ b/app/src/main/java/com/foobnix/ext/HtmlExtractor.java
@@ -8,7 +8,6 @@ import com.foobnix.hypen.HypenUtils;
 import com.foobnix.model.AppData;
 import com.foobnix.model.AppSP;
 import com.foobnix.model.AppState;
-import com.foobnix.model.SimpleMeta;
 import com.foobnix.pdf.info.ExtUtils;
 import com.foobnix.pdf.info.model.BookCSS;
 
@@ -21,7 +20,6 @@ import java.io.FileInputStream;
 import java.io.FileOutputStream;
 import java.io.IOException;
 import java.io.InputStreamReader;
-import java.util.ArrayList;
 import java.util.Locale;
 
 public class HtmlExtractor {
@@ -140,12 +138,14 @@ public class HtmlExtractor {
                 string = html.toString();
             }
 
-            if (BookCSS.get().isAutoHypens && TxtUtils.isNotEmpty(AppSP.get().hypenLang)) {
+            if (AppState.get().isEnableTextReplacement || (BookCSS.get().isAutoHypens && TxtUtils.isNotEmpty(AppSP.get().hypenLang))) {
                 HypenUtils.applyLanguage(AppSP.get().hypenLang);
                 int bodyInt = string.indexOf("<body");
                 bodyInt = string.indexOf(">", bodyInt);
 
-                string = string.substring(0, bodyInt) + HypenUtils.applyHypnes(string.substring(bodyInt));
+                String processedString = HypenUtils.applyTextReplacements(string.substring(bodyInt), AppData.get().getAllTextReplaces(), AppState.get().isEnableTextReplacement);
+                processedString = HypenUtils.applyHyphens(processedString);
+                string = string.substring(0, bodyInt) + processedString;
                 // string = Jsoup.clean(string, Whitelist.none());
             }
             // String string = html.toString();
@@ -220,8 +220,11 @@ public class HtmlExtractor {
 
             String string = Jsoup.clean(html.toString(), Safelist.basic());
 
+            if (AppState.get().isEnableTextReplacement) {
+                string = HypenUtils.applyTextReplacements(string, AppData.get().getAllTextReplaces());
+            }
             if (BookCSS.get().isAutoHypens) {
-                string = HypenUtils.applyHypnes(string);
+                string = HypenUtils.applyHyphens(string);
             }
 
             string = "<html><head></head><body style='text-align:justify;'><br/>" + string + "</body></html>";

--- a/app/src/main/java/com/foobnix/ext/RtfExtract.java
+++ b/app/src/main/java/com/foobnix/ext/RtfExtract.java
@@ -8,6 +8,7 @@ import com.foobnix.hypen.HypenUtils;
 import com.foobnix.model.AppData;
 import com.foobnix.model.AppSP;
 import com.foobnix.model.AppState;
+import com.foobnix.model.SimpleMeta;
 import com.foobnix.pdf.info.model.BookCSS;
 import com.rtfparserkit.converter.text.AbstractTextConverter;
 import com.rtfparserkit.parser.IRtfParser;
@@ -32,6 +33,7 @@ import java.io.InputStream;
 import java.io.PrintWriter;
 import java.util.ArrayList;
 import java.util.HashSet;
+import java.util.List;
 import java.util.Set;
 
 public class RtfExtract {
@@ -70,6 +72,7 @@ public class RtfExtract {
 
             HypenUtils.resetTokenizer();
 
+            List<SimpleMeta> replacements = AppData.get().getAllTextReplaces();
             parser.parse(source, new AbstractTextConverter() {
                 boolean isImage;
                 String format = "jpg";
@@ -81,7 +84,7 @@ public class RtfExtract {
 
                     String htmlEncode = TextUtils.htmlEncode(text);
                     if (AppState.get().isEnableTextReplacement) {
-                        htmlEncode = HypenUtils.applyTextReplacements(htmlEncode, AppData.get().getAllTextReplaces());
+                        htmlEncode = HypenUtils.applyTextReplacements(htmlEncode, replacements);
                     }
                     if (isEnableHypens) {
                         htmlEncode = HypenUtils.applyHyphens(htmlEncode);

--- a/app/src/main/java/com/foobnix/ext/RtfExtract.java
+++ b/app/src/main/java/com/foobnix/ext/RtfExtract.java
@@ -5,7 +5,9 @@ import android.text.TextUtils;
 import com.foobnix.android.utils.LOG;
 import com.foobnix.android.utils.TxtUtils;
 import com.foobnix.hypen.HypenUtils;
+import com.foobnix.model.AppData;
 import com.foobnix.model.AppSP;
+import com.foobnix.model.AppState;
 import com.foobnix.pdf.info.model.BookCSS;
 import com.rtfparserkit.converter.text.AbstractTextConverter;
 import com.rtfparserkit.parser.IRtfParser;
@@ -78,8 +80,11 @@ public class RtfExtract {
                 public void processExtractedText(String text) {
 
                     String htmlEncode = TextUtils.htmlEncode(text);
+                    if (AppState.get().isEnableTextReplacement) {
+                        htmlEncode = HypenUtils.applyTextReplacements(htmlEncode, AppData.get().getAllTextReplaces());
+                    }
                     if (isEnableHypens) {
-                        htmlEncode = HypenUtils.applyHypnes(htmlEncode);
+                        htmlEncode = HypenUtils.applyHyphens(htmlEncode);
                     }
                     printText(htmlEncode);
                     writer.print(" ");

--- a/app/src/main/java/com/foobnix/ext/TxtExtract.java
+++ b/app/src/main/java/com/foobnix/ext/TxtExtract.java
@@ -69,8 +69,11 @@ public class TxtExtract {
                 writer.println(line);
                 writer.println("</title></section>");
             } else {
+                if (AppState.get().isEnableTextReplacement) {
+                    line = HypenUtils.applyTextReplacements(line, AppData.get().getAllTextReplaces());
+                }
                 if (BookCSS.get().isAutoHypens && TxtUtils.isNotEmpty(AppSP.get().hypenLang)) {
-                    line = HypenUtils.applyHypnes(line);
+                    line = HypenUtils.applyHyphens(line);
                 }
                 writer.println("<p>" + line + "</p>");
             }
@@ -216,8 +219,11 @@ public class TxtExtract {
             line = line.replace("\n", "");
             line = line.replace("\r", "");
             line = TextUtils.htmlEncode(line);
+            if (AppState.get().isEnableTextReplacement) {
+                line = HypenUtils.applyTextReplacements(line, replacements);
+            }
             if (BookCSS.get().isAutoHypens && TxtUtils.isNotEmpty(AppSP.get().hypenLang)) {
-                line = HypenUtils.applyHypnes(line, replacements);
+                line = HypenUtils.applyHyphens(line);
             }
             line = line.trim();
 

--- a/app/src/main/java/com/foobnix/ext/TxtExtract.java
+++ b/app/src/main/java/com/foobnix/ext/TxtExtract.java
@@ -54,6 +54,7 @@ public class TxtExtract {
             HypenUtils.applyLanguage(AppSP.get().hypenLang);
         }
 
+        List<SimpleMeta> replacements = AppData.get().getAllTextReplaces();
         while ((line = input.readLine()) != null) {
             String trimLine = line.toLowerCase();
             if (line.isEmpty()) {
@@ -70,7 +71,7 @@ public class TxtExtract {
                 writer.println("</title></section>");
             } else {
                 if (AppState.get().isEnableTextReplacement) {
-                    line = HypenUtils.applyTextReplacements(line, AppData.get().getAllTextReplaces());
+                    line = HypenUtils.applyTextReplacements(line, replacements);
                 }
                 if (BookCSS.get().isAutoHypens && TxtUtils.isNotEmpty(AppSP.get().hypenLang)) {
                     line = HypenUtils.applyHyphens(line);
@@ -132,6 +133,12 @@ public class TxtExtract {
 
                 outLn = retab(line, 8);
                 outLn = TextUtils.htmlEncode(outLn);
+                if (AppState.get().isEnableTextReplacement) {
+                    outLn = HypenUtils.applyTextReplacements(outLn, replacements);
+                }
+                if (BookCSS.get().isAutoHypens && TxtUtils.isNotEmpty(AppSP.get().hypenLang)) {
+                    outLn = HypenUtils.applyHyphens(outLn);
+                }
 
                 if (TxtUtils.isLineStartEndUpperCase(outLn)) {
                     outLn = "<b>" + outLn + "</b>";

--- a/app/src/main/java/com/foobnix/hypen/HypenUtils.java
+++ b/app/src/main/java/com/foobnix/hypen/HypenUtils.java
@@ -1,8 +1,9 @@
 package com.foobnix.hypen;
 
+import android.text.TextUtils;
+
 import com.foobnix.android.utils.LOG;
 import com.foobnix.android.utils.TxtUtils;
-import com.foobnix.model.AppData;
 import com.foobnix.model.AppState;
 import com.foobnix.model.SimpleMeta;
 import com.foobnix.pdf.info.model.BookCSS;
@@ -55,25 +56,15 @@ public class HypenUtils {
 
     }
 
-    public static String applyHypnes(String htmlEncode) {
-        List<SimpleMeta> replacements = AppData.get().getAllTextReplaces();
-        return applyHypnesNewMy(htmlEncode, replacements);
-    }
-
-    public static String applyHypnes(String htmlEncode, List<SimpleMeta> replacements) {
-        return applyHypnesNewMy(htmlEncode, replacements);
-    }
-
-    private static String applyHypnesNewMy(final String input, List<SimpleMeta> replacements) {
-        if (input == null || input.length() == 0) {
+    public static String applyHyphens(String htmlEncode) {
+        if (htmlEncode == null || htmlEncode.isEmpty()) {
             return "";
         }
         //LOG.d("applyHypnesNewMy-input",input);
 
-        final String text = applyTextReplacements(input, replacements);
         final StringBuilder res = new StringBuilder();
 
-        tokenize(text, new TokensListener() {
+        tokenize(htmlEncode, new TokensListener() {
 
             @Override
             public void findOther(char ch) {
@@ -120,11 +111,11 @@ public class HypenUtils {
         return out;
     }
 
-    static String applyTextReplacements(final String input, List<SimpleMeta> replacements) {
+    public static String applyTextReplacements(final String input, List<SimpleMeta> replacements) {
         return applyTextReplacements(input, replacements, AppState.get().isEnableTextReplacement);
     }
 
-    static String applyTextReplacements(final String input, List<SimpleMeta> replacements, boolean isEnabled) {
+    public static String applyTextReplacements(final String input, List<SimpleMeta> replacements, boolean isEnabled) {
         if (!isEnabled || replacements == null || replacements.isEmpty()) {
             return input;
         }
@@ -175,7 +166,7 @@ public class HypenUtils {
         String value = text.toString();
         for (SimpleMeta it : replacements) {
             if (TxtUtils.isNotEmpty(it.name)) {
-                String replacement = escapeReplacementText(it.path);
+                String replacement = TextUtils.htmlEncode(it.path);
                 if (it.name.startsWith("*")) {
                     String regexp = it.name.substring(1);
                     value = TxtUtils.replaceAll(value, regexp, Matcher.quoteReplacement(replacement));
@@ -186,14 +177,6 @@ public class HypenUtils {
         }
         out.append(value);
         text.setLength(0);
-    }
-
-    private static String escapeReplacementText(String text) {
-        return text.replace("&", "&amp;")
-                .replace("<", "&lt;")
-                .replace(">", "&gt;")
-                .replace("\"", "&quot;")
-                .replace("'", "&#39;");
     }
 
     public static String applyHypnesOld2(String input) {

--- a/app/src/main/java/com/foobnix/hypen/HypenUtils.java
+++ b/app/src/main/java/com/foobnix/hypen/HypenUtils.java
@@ -12,6 +12,7 @@ import java.util.List;
 import java.util.Locale;
 import java.util.Map;
 import java.util.StringTokenizer;
+import java.util.regex.Matcher;
 
 
 public class HypenUtils {
@@ -69,9 +70,10 @@ public class HypenUtils {
         }
         //LOG.d("applyHypnesNewMy-input",input);
 
+        final String text = applyTextReplacements(input, replacements);
         final StringBuilder res = new StringBuilder();
 
-        tokenize(input, new TokensListener() {
+        tokenize(text, new TokensListener() {
 
             @Override
             public void findOther(char ch) {
@@ -80,19 +82,6 @@ public class HypenUtils {
 
             @Override
             public void findText(String w) {
-                if (AppState.get().isEnableTextReplacement && replacements != null) {
-                    for (SimpleMeta it : replacements) {
-                        if (TxtUtils.isNotEmpty(it.name)) {
-                            if (it.name.startsWith("*")) {
-                                String regexp = it.name.substring(1);
-                                w = TxtUtils.replaceAll(w, regexp, it.path);
-                            } else {
-                                w = w.replace(it.name, it.path);
-                            }
-                        }
-                    }
-                }
-
                 if (AppState.get().isBionicMode) {
                     res.append(TxtUtils.toBionicWord(w));
                     return;
@@ -129,6 +118,82 @@ public class HypenUtils {
         //LOG.d("applyHypnesNewMy-out",out);
 
         return out;
+    }
+
+    static String applyTextReplacements(final String input, List<SimpleMeta> replacements) {
+        return applyTextReplacements(input, replacements, AppState.get().isEnableTextReplacement);
+    }
+
+    static String applyTextReplacements(final String input, List<SimpleMeta> replacements, boolean isEnabled) {
+        if (!isEnabled || replacements == null || replacements.isEmpty()) {
+            return input;
+        }
+
+        StringBuilder out = new StringBuilder(input.length());
+        StringBuilder text = new StringBuilder();
+
+        for (int i = 0; i < input.length(); i++) {
+            char ch = input.charAt(i);
+
+            if (ch == '<') {
+                appendReplacedText(out, text, replacements);
+
+                int end = input.indexOf('>', i + 1);
+                if (end == -1) {
+                    out.append(input.substring(i));
+                    return out.toString();
+                }
+
+                out.append(input, i, end + 1);
+                i = end;
+                continue;
+            }
+
+            if (ch == '&') {
+                int end = input.indexOf(';', i + 1);
+                int tagStart = input.indexOf('<', i + 1);
+                if (end != -1 && (tagStart == -1 || end < tagStart)) {
+                    appendReplacedText(out, text, replacements);
+                    out.append(input, i, end + 1);
+                    i = end;
+                    continue;
+                }
+            }
+
+            text.append(ch);
+        }
+
+        appendReplacedText(out, text, replacements);
+        return out.toString();
+    }
+
+    private static void appendReplacedText(StringBuilder out, StringBuilder text, List<SimpleMeta> replacements) {
+        if (text.length() == 0) {
+            return;
+        }
+
+        String value = text.toString();
+        for (SimpleMeta it : replacements) {
+            if (TxtUtils.isNotEmpty(it.name)) {
+                String replacement = escapeReplacementText(it.path);
+                if (it.name.startsWith("*")) {
+                    String regexp = it.name.substring(1);
+                    value = TxtUtils.replaceAll(value, regexp, Matcher.quoteReplacement(replacement));
+                } else {
+                    value = value.replace(it.name, replacement);
+                }
+            }
+        }
+        out.append(value);
+        text.setLength(0);
+    }
+
+    private static String escapeReplacementText(String text) {
+        return text.replace("&", "&amp;")
+                .replace("<", "&lt;")
+                .replace(">", "&gt;")
+                .replace("\"", "&quot;")
+                .replace("'", "&#39;");
     }
 
     public static String applyHypnesOld2(String input) {

--- a/app/src/main/java/com/foobnix/pdf/info/view/DragingDialogs.java
+++ b/app/src/main/java/com/foobnix/pdf/info/view/DragingDialogs.java
@@ -423,7 +423,7 @@ public class DragingDialogs {
                                 EditText childFrom = (EditText) line.getChildAt(0);
                                 String from = childFrom.getText().toString();
                                 String to = ((EditText) line.getChildAt(2)).getText().toString();
-                                from = from.replace(" ", "").trim();
+                                from = from.trim();
 
                                 LOG.d("TTS-add", from, to);
 

--- a/app/src/main/java/org/ebookdroid/droids/DocContext.java
+++ b/app/src/main/java/org/ebookdroid/droids/DocContext.java
@@ -6,6 +6,7 @@ import com.foobnix.ext.CbzCbrExtractor;
 import com.foobnix.ext.Fb2Extractor;
 import com.foobnix.hypen.HypenUtils;
 import com.foobnix.libmobi.LibMobi;
+import com.foobnix.model.AppData;
 import com.foobnix.model.AppSP;
 import com.foobnix.model.AppState;
 import com.foobnix.pdf.info.model.BookCSS;
@@ -20,7 +21,6 @@ import java.io.FileInputStream;
 import java.io.FileOutputStream;
 import java.io.InputStreamReader;
 import java.io.OutputStream;
-import java.util.ArrayList;
 
 public class DocContext extends PdfContext {
 
@@ -30,7 +30,7 @@ public class DocContext extends PdfContext {
 
     @Override
     public File getCacheFileName(String fileNameOriginal) {
-        fileNameOriginal = fileNameOriginal + BookCSS.get().isAutoHypens + AppSP.get().hypenLang + AppSP.get().isDouble + AppState.get().isAccurateFontSize + BookCSS.get().isCapitalLetter;
+        fileNameOriginal = fileNameOriginal + BookCSS.get().isAutoHypens + AppSP.get().hypenLang + AppSP.get().isDouble + AppState.get().isAccurateFontSize + BookCSS.get().isCapitalLetter + AppState.get().textReplacementHash;
         cacheFile = new File(CacheZipUtils.CACHE_BOOK_DIR, fileNameOriginal.hashCode() + EXT_DOC_HTML);
         return cacheFile;
     }
@@ -57,7 +57,7 @@ public class DocContext extends PdfContext {
                 OutputStream out = new BufferedOutputStream(new FileOutputStream(cacheFile));
 
                 HypenUtils.applyLanguage(AppSP.get().hypenLang);
-                Fb2Extractor.generateHyphenFileEpub(new InputStreamReader(in), null, out, null, null, 0, new ArrayList<>());
+                Fb2Extractor.generateHyphenFileEpub(new InputStreamReader(in), null, out, null, null, 0, AppData.get().getAllTextReplaces());
                 out.close();
                 in.close();
 

--- a/app/src/main/java/org/ebookdroid/droids/DocxContext.java
+++ b/app/src/main/java/org/ebookdroid/droids/DocxContext.java
@@ -5,6 +5,7 @@ import com.foobnix.android.utils.TxtUtils;
 import com.foobnix.ext.CacheZipUtils;
 import com.foobnix.hypen.HypenUtils;
 import com.foobnix.mobi.parser.IOUtils;
+import com.foobnix.model.AppData;
 import com.foobnix.model.AppSP;
 import com.foobnix.model.AppState;
 import com.foobnix.pdf.info.model.BookCSS;
@@ -70,11 +71,14 @@ public class DocxContext extends PdfContext {
 
                 String html = result.getValue();
                 html = html.replace("<br /><br />", "<empty-line />");
+                if (AppState.get().isEnableTextReplacement) {
+                    html = HypenUtils.applyTextReplacements(html, AppData.get().getAllTextReplaces());
+                }
                 if (BookCSS.get().isAutoHypens && TxtUtils.isNotEmpty(AppSP.get().hypenLang)) {
                     LOG.d("docx-isAutoHypens", BookCSS.get().isAutoHypens);
                     HypenUtils.applyLanguage(AppSP.get().hypenLang);
                     HypenUtils.resetTokenizer();
-                    html = HypenUtils.applyHypnes(html);
+                    html = HypenUtils.applyHyphens(html);
                 }
 
                 FileOutputStream out = new FileOutputStream(cacheFile);

--- a/app/src/main/java/org/ebookdroid/droids/DocxContext.java
+++ b/app/src/main/java/org/ebookdroid/droids/DocxContext.java
@@ -21,7 +21,6 @@ import org.zwobble.mammoth.images.ImageConverter;
 import java.io.File;
 import java.io.FileOutputStream;
 import java.io.IOException;
-import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.Map;
 
@@ -37,7 +36,8 @@ public class DocxContext extends PdfContext {
                 AppSP.get().isDouble +
                 AppState.get().isAccurateFontSize +
                 BookCSS.get().documentStyle+
-                BookCSS.get().isCapitalLetter;
+                BookCSS.get().isCapitalLetter +
+                AppState.get().textReplacementHash;
         cacheFile = new File(CacheZipUtils.CACHE_BOOK_DIR, fileNameOriginal.hashCode() + ".html");
         return cacheFile;
     }

--- a/app/src/main/java/org/ebookdroid/droids/Fb2Context.java
+++ b/app/src/main/java/org/ebookdroid/droids/Fb2Context.java
@@ -30,7 +30,8 @@ public class Fb2Context extends PdfContext {
                 AppSP.get().isDouble +
                 //AppState.get().isAccurateFontSize +
                 BookCSS.get().documentStyle +
-                BookCSS.get().isCapitalLetter;
+                BookCSS.get().isCapitalLetter +
+                AppState.get().textReplacementHash;
         cacheFile = new File(CacheZipUtils.CACHE_BOOK_DIR, fileNameOriginal.hashCode() + ".epub");
         return cacheFile;
     }

--- a/app/src/main/java/org/ebookdroid/droids/MdContext.java
+++ b/app/src/main/java/org/ebookdroid/droids/MdContext.java
@@ -9,6 +9,7 @@ import com.foobnix.ext.FooterNote;
 import com.foobnix.hypen.HypenUtils;
 import com.foobnix.model.AppData;
 import com.foobnix.model.AppSP;
+import com.foobnix.model.AppState;
 import com.foobnix.model.SimpleMeta;
 import com.foobnix.pdf.info.model.BookCSS;
 import com.google.common.io.CharSource;
@@ -200,7 +201,7 @@ public class MdContext extends PdfContext {
                 HypenUtils.applyLanguage(AppSP.get().hypenLang);
             }
 
-        List<SimpleMeta> replacements = AppData.get().getAllTextReplaces();
+            List<SimpleMeta> replacements = AppData.get().getAllTextReplaces();
 
             String l;
             String line = "";
@@ -214,9 +215,11 @@ public class MdContext extends PdfContext {
                     continue;
                 }
 
-
+                if (AppState.get().isEnableTextReplacement) {
+                    line = HypenUtils.applyTextReplacements(line, replacements);
+                }
                 if (BookCSS.get().isAutoHypens) {
-                    line = HypenUtils.applyHypnes(line,replacements);
+                    line = HypenUtils.applyHyphens(line);
                 }
 
                 html.append("<p>");

--- a/app/src/main/java/org/ebookdroid/droids/MobiContext.java
+++ b/app/src/main/java/org/ebookdroid/droids/MobiContext.java
@@ -6,6 +6,7 @@ import com.foobnix.ext.EpubExtractor;
 import com.foobnix.ext.FooterNote;
 import com.foobnix.ext.MobiExtract;
 import com.foobnix.model.AppSP;
+import com.foobnix.model.AppState;
 import com.foobnix.pdf.info.AppsConfig;
 import com.foobnix.pdf.info.JsonHelper;
 import com.foobnix.pdf.info.model.BookCSS;
@@ -26,7 +27,7 @@ public class MobiContext extends PdfContext {
 
     @Override
     public File getCacheFileName(String fileName) {
-        originalHashCode = (fileName + BookCSS.get().isAutoHypens + AppSP.get().hypenLang).hashCode();
+        originalHashCode = (fileName + BookCSS.get().isAutoHypens + AppSP.get().hypenLang + AppState.get().textReplacementHash).hashCode();
         cacheFile = new File(CacheZipUtils.CACHE_BOOK_DIR, originalHashCode + "" + originalHashCode + ".epub");
         return cacheFile;
     }
@@ -42,13 +43,13 @@ public class MobiContext extends PdfContext {
 
         } else {
             try {
-                int outName = BookCSS.get().isAutoHypens ? "temp".hashCode() : originalHashCode;
+                boolean isProcess = AppState.get().isEnableTextReplacement || BookCSS.get().isAutoHypens;
+                int outName = isProcess ? "temp".hashCode() : originalHashCode;
 
                 FooterNote extract = MobiExtract.extract(fileName, CacheZipUtils.CACHE_BOOK_DIR.getPath(), outName + "");
                 fileNameEpub = extract.path;
                 LOG.d("Context", "MobiContext outName", outName, extract.path);
-                if (BookCSS.get().isAutoHypens) {
-
+                if (isProcess) {
                     EpubExtractor.proccessHypens(fileNameEpub, cacheFile.getPath(), null);
                     fileNameEpub = cacheFile.getPath();
                 }

--- a/app/src/main/java/org/ebookdroid/droids/OdtContext.java
+++ b/app/src/main/java/org/ebookdroid/droids/OdtContext.java
@@ -4,6 +4,7 @@ import com.foobnix.android.utils.LOG;
 import com.foobnix.ext.CacheZipUtils;
 import com.foobnix.ext.Fb2Extractor;
 import com.foobnix.hypen.HypenUtils;
+import com.foobnix.model.AppData;
 import com.foobnix.model.AppSP;
 import com.foobnix.model.AppState;
 import com.foobnix.pdf.info.model.BookCSS;
@@ -18,7 +19,6 @@ import java.io.FileInputStream;
 import java.io.FileOutputStream;
 import java.io.InputStreamReader;
 import java.io.OutputStream;
-import java.util.ArrayList;
 
 import at.stefl.opendocument.java.odf.LocatedOpenDocumentFile;
 import at.stefl.opendocument.java.odf.OpenDocument;
@@ -36,7 +36,7 @@ public class OdtContext extends PdfContext {
 
     @Override
     public File getCacheFileName(String fileNameOriginal) {
-        fileNameCache = fileNameOriginal + BookCSS.get().isAutoHypens + AppSP.get().hypenLang + AppSP.get().isDouble + AppState.get().isAccurateFontSize + BookCSS.get().isCapitalLetter;
+        fileNameCache = fileNameOriginal + BookCSS.get().isAutoHypens + AppSP.get().hypenLang + AppSP.get().isDouble + AppState.get().isAccurateFontSize + BookCSS.get().isCapitalLetter + AppState.get().textReplacementHash;
         cacheFile = new File(CacheZipUtils.CACHE_BOOK_DIR, fileNameCache.hashCode() + "-0.html");
         return cacheFile;
     }
@@ -86,7 +86,7 @@ public class OdtContext extends PdfContext {
                 OutputStream out = new BufferedOutputStream(new FileOutputStream(cacheFile));
 
                 HypenUtils.applyLanguage(AppSP.get().hypenLang);
-                Fb2Extractor.generateHyphenFileEpub(new InputStreamReader(in), null, out, null,null,0, new ArrayList<>());
+                Fb2Extractor.generateHyphenFileEpub(new InputStreamReader(in), null, out, null,null,0, AppData.get().getAllTextReplaces());
                 out.close();
                 in.close();
 

--- a/app/src/main/java/org/ebookdroid/droids/RtfContext.java
+++ b/app/src/main/java/org/ebookdroid/droids/RtfContext.java
@@ -4,6 +4,7 @@ import com.foobnix.android.utils.LOG;
 import com.foobnix.ext.CacheZipUtils;
 import com.foobnix.ext.RtfExtract;
 import com.foobnix.model.AppSP;
+import com.foobnix.model.AppState;
 import com.foobnix.pdf.info.model.BookCSS;
 
 import org.ebookdroid.core.codec.CodecDocument;
@@ -18,7 +19,7 @@ public class RtfContext extends PdfContext {
 
     @Override
     public File getCacheFileName(String fileNameOriginal) {
-        fileNameOriginal = fileNameOriginal + BookCSS.get().isAutoHypens + AppSP.get().hypenLang;
+        fileNameOriginal = fileNameOriginal + BookCSS.get().isAutoHypens + AppSP.get().hypenLang + AppState.get().textReplacementHash;
         cacheFile = new File(CacheZipUtils.CACHE_BOOK_DIR, fileNameOriginal.hashCode() + ".html");
         return cacheFile;
     }


### PR DESCRIPTION
This PR addresses the problems described in issues #1542 and #1283.  
Previously, text replacement couldn't replace patterns that included special characters or multiple words, such as "I'm", "y/n", or "John Doe". This PR fixes that.

Changes made:
- Splits hyphenation and text replacement into two independent operations, making the behavior more configurable.
- Safely replaces text patterns while leaving HTML/XML tags unchanged.
- Ensures text replacement is applied to all supported text formats when enabled.
- Refreshes book caches when replacement settings change.
