### PR TITLE
Fix translation of "Memory" in German

### DIFF
--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -647,7 +647,7 @@
    <string name="show_series_number_in_title">Seriennummer im Titel anzeigen</string>
    <string name="graphics_scale">Grafik skalieren</string>
    <string name="сreate_a_folder_with_the_name_of_the_book">Ordner mit dem Namen des Buches erstellen</string>
-   <string name="memory">Erinnerung</string>
+   <string name="memory">Speicher</string>
    <string name="accessibility">Barrierefreiheit</string>
    <string name="web_search_google">Websuche (Google, ...)</string>
    <string name="synced_books">Synchronisierte Bücher</string>


### PR DESCRIPTION
The word "Memory" was translated incorrectly in German. It was translated as "Erinnerung" which means it's about something you have remembered. But the word in English is actually talking about the disk memory, so the current German translation was very weird and confusing.

The rest of the German translation seems more or less fine atm.