### PR TITLE
Resolves #1538

### DIFF
--- a/app/src/main/java/com/foobnix/sys/AdvGuestureDetector.java
+++ b/app/src/main/java/com/foobnix/sys/AdvGuestureDetector.java
@@ -341,7 +341,6 @@ public class AdvGuestureDetector extends SimpleOnGestureListener implements IMul
     public void onLongPress(final MotionEvent e) {
         LOG.d("ADV-onLongPress");
         if (!AppState.get().isAllowTextSelection) {
-            Toast.makeText(LibreraApp.context, R.string.text_highlight_mode_is_disable, Toast.LENGTH_LONG).show();
             return;
         }
         if(AppState.get().isCropNotification) {


### PR DESCRIPTION
Removed the toast to notify that text selection is disabled on long press check. 

It seems counter intuitive to me that this exists?
Text selection is a user option and on by default, if it's off it can be fairly assumed it is intentionally off.

I really dislike the toast popup when I use the app. It's a big detractor to usability, it ignores app controlled brightness and is just plain frustrating to see.