### PR TITLE
fix: eye rest reminder counting non-reading time

### DIFF
--- a/app/src/main/java/com/foobnix/pdf/info/wrapper/DocumentController.java
+++ b/app/src/main/java/com/foobnix/pdf/info/wrapper/DocumentController.java
@@ -592,6 +592,7 @@ public abstract class DocumentController {
     }
 
     public void onResume() {
+        resetReadTimer();
 
         try {
             if (getPageCount() != 0) {

--- a/app/src/main/java/com/foobnix/pdf/info/wrapper/DocumentWrapperUI.java
+++ b/app/src/main/java/com/foobnix/pdf/info/wrapper/DocumentWrapperUI.java
@@ -2109,7 +2109,6 @@ public class DocumentWrapperUI {
     public void onPause() {
         LOG.d("DocumentWrapperUI", "onPause");
         handlerTimer.removeCallbacks(updateTimePower);
-        dc.resetReadTimer();
     }
 
     public View.OnClickListener onPrefTop = new View.OnClickListener() {

--- a/app/src/main/java/com/foobnix/pdf/search/activity/HorizontalViewActivity.java
+++ b/app/src/main/java/com/foobnix/pdf/search/activity/HorizontalViewActivity.java
@@ -1580,10 +1580,6 @@ public class HorizontalViewActivity extends AdsFragmentActivity {
         handler.postDelayed(closeRunnable, AppState.APP_CLOSE_AUTOMATIC);
         handlerTimer.removeCallbacks(updateTimePower);
         GFile.runSyncService(this);
-        if (dc != null) {
-            dc.resetReadTimer();
-        }
-
     }
 
     public synchronized void nextPage() {


### PR DESCRIPTION
The timer was being reset only on app close. Not on app open. Leading to non-reading time being counted towards the eye rest reminder time.

Fix moving `resetReadTimer` to `onResume` from `onPause`

fixes #1568