### PR TITLE
fix crop white space toggle reflow

### DIFF
--- a/app/src/main/java/com/foobnix/model/AppBook.java
+++ b/app/src/main/java/com/foobnix/model/AppBook.java
@@ -20,7 +20,7 @@ public class AppBook implements CurrentPageListener {
 
     public int z = 100;//z
     public boolean sp = false;//split pages
-    public boolean cp = false; //crop pages
+    public volatile boolean cp = false; //crop pages (read by the decode thread)
     public boolean dp = false; //double pages normal
     public boolean dc = false; //double pages cover
     public int lk = LOCK_NONE;

--- a/app/src/main/java/org/ebookdroid/core/DecodeService.java
+++ b/app/src/main/java/org/ebookdroid/core/DecodeService.java
@@ -48,6 +48,8 @@ public interface DecodeService {
 
 	void updateViewState(ViewState viewState);
 
+	default void invalidateCropStamp() {}
+
 	boolean isPageSizeCacheable();
 
 	int getPixelFormat();

--- a/app/src/main/java/org/ebookdroid/core/DecodeServiceBase.java
+++ b/app/src/main/java/org/ebookdroid/core/DecodeServiceBase.java
@@ -53,6 +53,11 @@ public class DecodeServiceBase implements DecodeService {
 
     static final AtomicLong TASK_ID_SEQ = new AtomicLong();
 
+    // Bumped whenever the crop setting is toggled so that decode tasks scheduled
+    // for the previous crop state can be recognised as obsolete and dropped
+    // instead of publishing stale cropped/uncropped geometry or bitmaps.
+    final java.util.concurrent.atomic.AtomicInteger cropStamp = new java.util.concurrent.atomic.AtomicInteger();
+
     final CodecContext codecContext;
     final AtomicBoolean isRecycled = new AtomicBoolean();
     final AtomicReference<ViewState> viewState = new AtomicReference<ViewState>();
@@ -151,6 +156,11 @@ public class DecodeServiceBase implements DecodeService {
     @Override
     public void updateViewState(final ViewState viewState) {
         this.viewState.set(viewState);
+    }
+
+    @Override
+    public void invalidateCropStamp() {
+        cropStamp.incrementAndGet();
     }
 
     @Override
@@ -313,13 +323,18 @@ public class DecodeServiceBase implements DecodeService {
 
             r = getScaledSize(task.node, task.viewState.zoom, croppedPageBounds, vuPage);
 
-            final RectF actualSliceBounds = task.node.croppedBounds != null ? task.node.croppedBounds : task.node.pageSliceBounds;
+            // Only render the cropped slice when cropping is currently enabled.
+            // A crop-ON decode that was already in flight when the user turned
+            // crop off could otherwise keep rendering the cropped region using a
+            // stale node.croppedBounds, so the page never appears to un-crop.
+            final boolean cropping = task.viewState.book != null && task.viewState.book.cp;
+            final RectF actualSliceBounds = (cropping && task.node.croppedBounds != null) ? task.node.croppedBounds : task.node.pageSliceBounds;
 
             // TempHolder.lock.lock();
             final BitmapRef bitmap = vuPage.renderBitmap(r.width(), r.height(), actualSliceBounds, true);
             // TempHolder.lock.unlock();
 
-            if (executor.isTaskDead(task)) {
+            if (executor.isTaskDead(task) || task.cropStamp != cropStamp.get()) {
                 BitmapManager.release(bitmap);
                 return;
             }
@@ -339,6 +354,14 @@ public class DecodeServiceBase implements DecodeService {
                 task.node.page.texts = vuPage.getText();
             }
             // TempHolder.lock.unlock();
+
+            // Final validity check with no slow work before completion: if the
+            // task became obsolete (e.g. the crop setting was toggled) drop it so
+            // it cannot install a stale bitmap or cancel the replacement task.
+            if (executor.isTaskDead(task) || task.cropStamp != cropStamp.get()) {
+                BitmapManager.release(bitmap);
+                return;
+            }
 
             finishDecoding(task, vuPage, bitmap, r, croppedPageBounds);
             // test
@@ -395,10 +418,22 @@ public class DecodeServiceBase implements DecodeService {
             LOG.d("DJVU1-1a", vuPage.getWidth(), vuPage.getHeight());
             LOG.d("DJVU1-1b", rootBitmap.getBitmap().getWidth(), rootBitmap.getBitmap().getHeight());
 
-            root.croppedBounds = PageCropper.getCropBounds(rootBitmap.getBitmap(), rootRect, new RectF(0, 0, 1f, 1f));
-            LOG.d("DJVU1-2", root.croppedBounds.width(), root.croppedBounds.height());
+            final RectF cropBounds = PageCropper.getCropBounds(rootBitmap.getBitmap(), rootRect, new RectF(0, 0, 1f, 1f));
+            LOG.d("DJVU1-2", cropBounds.width(), cropBounds.height());
 
             BitmapManager.release(rootBitmap);
+
+            // The crop detection above is slow; re-check right before publishing
+            // (with no slow work in between) that cropping is still enabled and
+            // this task is still current. This prevents a decode started while
+            // crop was on from re-cropping the page after the user turned crop
+            // off - the stale cropped aspect ratio would otherwise stick.
+            if (task.viewState.book == null || !task.viewState.book.cp || executor.isTaskDead(task)
+                    || task.cropStamp != cropStamp.get()) {
+                return null;
+            }
+
+            root.croppedBounds = cropBounds;
 
             final ViewState viewState = task.viewState;
             final float pageWidth = vuPage.getWidth() * root.croppedBounds.width();
@@ -953,12 +988,14 @@ public class DecodeServiceBase implements DecodeService {
         final PageTreeNode node;
         final ViewState viewState;
         final int pageNumber;
+        final int cropStamp;
 
         DecodeTask(final ViewState viewState, final PageTreeNode node) {
             super(2);
             this.pageNumber = node.page.index.docIndex;
             this.viewState = viewState;
             this.node = node;
+            this.cropStamp = DecodeServiceBase.this.cropStamp.get();
         }
 
         @Override

--- a/app/src/main/java/org/ebookdroid/core/Page.java
+++ b/app/src/main/java/org/ebookdroid/core/Page.java
@@ -120,6 +120,17 @@ public class Page {
         return bounds;
     }
 
+    /**
+     * Drops any cached crop geometry so the page is laid out and rendered for
+     * the current crop setting. Without this, toggling "Crop White Space" keeps
+     * the previously computed cropped aspect ratio and slice bounds until the
+     * page is scrolled off-screen and re-decoded.
+     */
+    public void resetCropping() {
+        setAspectRatio(cpi);
+        nodes.resetCropping();
+    }
+
     public void recycle(final List<Bitmaps> bitmapsToRecycle) {
         texts = null;
         recycled = true;

--- a/app/src/main/java/org/ebookdroid/core/PageTree.java
+++ b/app/src/main/java/org/ebookdroid/core/PageTree.java
@@ -42,6 +42,17 @@ public class PageTree {
         return this.treeNodes;
     }
 
+    synchronized void resetCropping() {
+        root.croppedBounds = null;
+        if (this.treeNodes != null) {
+            for (final PageTreeNode node : this.treeNodes) {
+                if (node != null) {
+                    node.croppedBounds = null;
+                }
+            }
+        }
+    }
+
     public boolean process(final IEvent event, final PageTreeLevel level, final boolean createNodes) {
         boolean res = false;
         if (createNodes || level.start < maxNodeId) {

--- a/app/src/main/java/org/ebookdroid/ui/viewer/ViewerActivityController.java
+++ b/app/src/main/java/org/ebookdroid/ui/viewer/ViewerActivityController.java
@@ -41,6 +41,7 @@ import org.ebookdroid.common.settings.listeners.IBookSettingsChangeListener;
 import org.ebookdroid.common.settings.types.DocumentViewMode;
 import org.ebookdroid.core.DecodeService;
 import org.ebookdroid.core.ViewState;
+import org.ebookdroid.core.Page;
 import org.ebookdroid.core.events.CurrentPageListener;
 import org.ebookdroid.core.events.DecodingProgressListener;
 import org.ebookdroid.core.models.DocumentModel;
@@ -403,15 +404,48 @@ public class ViewerActivityController extends ActionController<VerticalViewActiv
     }
 
     public void toggleCrop(boolean isCrop) {
-        getDocumentController().toggleRenderingEffects();
+        // The crop toggle UI updates AppSP.isCrop but the renderer reads the
+        // per-book flag (bs.cp), which is normally only synced later by
+        // saveCurrentPage(). Sync it here so the change takes effect immediately
+        // instead of only after the user scrolls or changes page.
+        final AppBook bs = SettingsManager.getBookSettings();
+        if (bs != null) {
+            bs.cp = isCrop;
+        }
 
-        final IViewController newDc = switchDocumentController(SettingsManager.getBookSettings());
-        newDc.init(null);
-        newDc.show();
+        // Invalidate decode tasks scheduled for the previous crop state so any
+        // still in flight are dropped instead of publishing stale geometry.
+        getDecodeService().invalidateCropStamp();
 
-        currentPageChanged(documentModel.getCurrentIndex().docIndex, getDocumentController().getBase()
-                                                                                            .getDocumentModel()
-                                                                                            .getPageCount());
+        final IViewController dc = getDocumentController();
+
+        // Remember the current page so we can keep it in view after the page
+        // sizes change (otherwise the kept absolute scroll offset can jump to a
+        // different page or past the new bottom limit).
+        final int currentPage = documentModel.getCurrentIndex().viewIndex;
+
+        // Drop cached crop geometry (cropped aspect ratio + slice bounds) so the
+        // visible pages are reflowed for the new setting.
+        if (documentModel != null) {
+            for (final Page page : documentModel.getPages()) {
+                if (page != null) {
+                    page.resetCropping();
+                }
+            }
+        }
+
+        // Re-layout with the reset (uncropped) sizes and re-decode in place. When
+        // cropping is enabled the decode step recomputes the crop bounds. Doing
+        // this in place - like night-mode toggling - instead of recreating the
+        // view controller avoids the page-info reload (retrievePagesInfo) whose
+        // caching/timing made the reflow unreliable on some files.
+        dc.invalidatePageSizes(IViewController.InvalidateSizeReason.INIT, null);
+        dc.goToPage(currentPage);
+        dc.toggleRenderingEffects();
+
+        currentPageChanged(documentModel.getCurrentIndex().docIndex, dc.getBase()
+                                                                        .getDocumentModel()
+                                                                        .getPageCount());
 
     }
 


### PR DESCRIPTION
Hi, I've been having this issue and let AI take a stab at it, this is what it came up with:

## Fix: "Crop White Space" toggle doesn't reflow reliably

### Problem
Toggling **Crop White Space** off does not reliably reflow the pages to the uncropped layout — the view kept the cropped aspect ratio/geometry until I scrolled or changed page.

This is a big problem for me as annotations/drawings added while in this stale state (meaning after toggling crop off I immediately opened the annotations dialog) showed up offset from where they were drawn, or didn't show up until the file was saved/closed and reopened — because drawing coordinates were mapped against the stale (cropped) layout.

### Root causes
1. **Stale flag.** The renderer reads the per-book crop flag `bs.cp`, but the toggle only updated the global `AppSP.isCrop`. `bs.cp` was synced later by `saveCurrentPage()` on scroll — which is why *moving the page* "fixed" it.
2. **Fragile refresh path.** `toggleCrop` recreated the view controller, which reloaded page info via `initPages()` → `retrievePagesInfo()` (page-size cache file I/O) and raced with the decode thread pool — making the reflow file-/timing-dependent (reliable when page info was cached, flaky otherwise).
3. **Stale decodes.** Decode tasks already in flight when crop was toggled could publish stale cropped geometry/aspect or install a stale bitmap.

### Fix
- **In-place refresh** (like night-mode toggling) instead of recreating the controller: sync `bs.cp`, reset cached crop geometry, `invalidatePageSizes`, re-anchor the current page, then `toggleRenderingEffects()`. Removes the `initPages`/`retrievePagesInfo` reload race.
- `Page.resetCropping()` / `PageTree.resetCropping()` clear the cached cropped aspect ratio and per-node `croppedBounds`.
- **Concurrency hardening** in `DecodeServiceBase`: a per-`DecodeTask` crop-generation stamp plus a live-`cp` render-slice gate. Obsolete tasks are dropped right before publishing crop geometry and right before completion, so a stale decode can neither re-crop the layout nor install a stale bitmap. `AppBook.cp` is now `volatile` for cross-thread visibility; `DecodeService.invalidateCropStamp()` is added as a default no-op.

### Testing
- Built and ran the `fdroid` variant (`assembleFdroidDebug` + `assembleFdroid`).
- Manually verified: toggling crop on/off now crops/un-crops immediately across files that were previously flaky.