### PR TITLE
feature: allow annotating while crop enabled

### DIFF
--- a/app/src/main/java/com/foobnix/pdf/info/wrapper/DocumentWrapperUI.java
+++ b/app/src/main/java/com/foobnix/pdf/info/wrapper/DocumentWrapperUI.java
@@ -346,10 +346,6 @@ public class DocumentWrapperUI {
 
         @Override
         public void onClick(final View arg0) {
-            if (AppSP.get().isCrop) {
-                onCrop.onClick(null);
-            }
-
             DragingDialogs.dialogEditColors(anchor, dc, drawView, false, new Runnable() {
                 @Override
                 public void run() {
@@ -1954,7 +1950,7 @@ public class DocumentWrapperUI {
     public void hideShowEditIcon() {
         if (dc != null && !BookType.PDF.is(dc.getCurrentBook().getPath())) {
             editTop2.setVisibility(View.GONE);
-        } else if (AppSP.get().isCrop || AppSP.get().isCut) {
+        } else if (AppSP.get().isCut) {
             editTop2.setVisibility(View.GONE);
         } else {
             boolean passwordProtected = dc.isPasswordProtected();

--- a/app/src/main/java/com/foobnix/sys/VerticalModeController.java
+++ b/app/src/main/java/com/foobnix/sys/VerticalModeController.java
@@ -323,11 +323,6 @@ public class VerticalModeController extends DocumentController {
 
     @Override
     public void saveChanges(final List<PointF> points, final int color) {
-        if (SettingsManager.getBookSettings().cp) {
-            onCrop();
-            return;
-        }
-
         final float zoom = ctr.getZoomModel().getZoom();
         int scrollX = ctr.getDocumentController().getView().getScrollX();
         int scrollY = ctr.getDocumentController().getView().getScrollY();
@@ -345,14 +340,6 @@ public class VerticalModeController extends DocumentController {
             Iterable<Page> pages = ctr.getDocumentModel().getPages(first, last);
             for (Page page : pages) {
                 RectF pbounds = page.getBounds(zoom);
-                float aspect = page.getAspectRatio();
-                float k = page.cpi.width / pbounds.width();
-
-                LOG.d("PAGE #", page.index.viewIndex);
-                LOG.d("PAGE wxh", page.cpi.width, page.cpi.height);
-                LOG.d("PAGE dpi", page.cpi.dpi, page.cpi.dpi);
-                LOG.d("pbounds p", pbounds, "z", zoom, "aspect", aspect);
-                LOG.d("pbounds p", pbounds, "z", zoom, "aspect", aspect);
 
                 if (RectF.intersects(pbounds, tapRect)) {
                     int pNumber = page.index.docIndex;
@@ -361,11 +348,23 @@ public class VerticalModeController extends DocumentController {
                         list = new ArrayList<PointF>();
                     }
 
-                    p.x += scrollX;
-                    p.y += scrollY - pbounds.top;
+                    // Position of the touch within the on-screen page box (0..1).
+                    float normX = (p.x + scrollX - pbounds.left) / pbounds.width();
+                    float normY = (p.y + scrollY - pbounds.top) / pbounds.height();
 
-                    p.x = p.x * k;
-                    p.y = p.y * k;
+                    // When "Crop White Space" is enabled the on-screen page shows
+                    // only the cropped sub-region of the full page, so remap the
+                    // normalized point back into the full page before converting
+                    // to PDF coordinates. Annotations are always stored in full
+                    // page coordinates so they render correctly cropped or not.
+                    RectF crop = page.getCroppedBounds();
+                    if (crop != null) {
+                        normX = crop.left + normX * crop.width();
+                        normY = crop.top + normY * crop.height();
+                    }
+
+                    p.x = normX * page.cpi.width;
+                    p.y = normY * page.cpi.height;
 
                     list.add(p);
                     result.put(pNumber, list);

--- a/app/src/main/java/org/ebookdroid/core/AbstractViewController.java
+++ b/app/src/main/java/org/ebookdroid/core/AbstractViewController.java
@@ -571,7 +571,7 @@ public abstract class AbstractViewController extends AbstractComponentController
                     continue;
                 }
                 for (Annotation a : page.annotations) {
-                    RectF wordRect = page.getPageRegion(bounds, a);
+                    RectF wordRect = page.getPageRegion(bounds, new RectF(a));
                     if (wordRect == null) {
                         continue;
                     }

--- a/app/src/main/java/org/ebookdroid/core/Page.java
+++ b/app/src/main/java/org/ebookdroid/core/Page.java
@@ -120,6 +120,15 @@ public class Page {
         return bounds;
     }
 
+    /**
+     * The visible crop region as a normalized rectangle (0..1) of the full page,
+     * or null when the page has not been cropped. When "Crop White Space" is
+     * enabled the on-screen page shows only this sub-region of the full page.
+     */
+    public RectF getCroppedBounds() {
+        return nodes.root.croppedBounds;
+    }
+
     public void recycle(final List<Bitmaps> bitmapsToRecycle) {
         texts = null;
         recycled = true;


### PR DESCRIPTION
Sorry for the 2 AI PRs today, but these were both very big annoyances I was experiencing...

### Motivation
I use the "Auto-crop white space" feature, but also am a heavy user of annotations, and was constantly having to toggle cropping off and then open the annotations editor (and until https://github.com/foobnix/LibreraReader/pull/1589, I had to drag or change page to force a re-flow to work around that bug).

### What this does
- Shows the annotation button while cropped (removes the `isCrop` hide condition in `hideShowEditIcon`; still hidden for split/cut, password, and non-PDF).
- Lets you draw directly on the cropped page. Strokes are mapped from the visible (cropped) region back into **full-page** PDF coordinates, so the annotation lands under your finger and renders correctly whether crop is on or off.

### How it works
When crop is on, the on-screen page shows only the normalized crop sub-region (`page.nodes.root.croppedBounds`, a 0..1 rect of the full page) scaled to fill the page box. `VerticalModeController.saveChanges` now: (1) normalizes the touch within the on-screen page box, (2) remaps it through `croppedBounds` into full-page space (only when cropped), (3) converts to PDF points (`× cpi.width/height`) as before.

Annotations are always stored in full-page coordinates (unchanged for the uncropped case), so no migration or display change is needed. A new `Page.getCroppedBounds()` accessor exposes the region.

### Included fix (coupled)
Annotation delete/select hit-testing (`AbstractViewController.isAnnotationTap`) passed the cached annotation rect straight into `Page.getPageRegion`, whose crop branch mutates it **in place** — so repeated taps on a cropped page compounded the transform and drifted. Now passes a defensive copy (`new RectF(a)`), matching the existing link hit-test.

### Testing
- Built and ran the `fdroid` variant (`assembleFdroidDebug` + `assembleFdroid`).
- Manually verified: annotate directly while cropped — strokes land correctly and display cropped or uncropped.