### PR TITLE
Fix multiple taps needed to start TTS

### DIFF
--- a/app/src/main/java/com/foobnix/tts/TTSEngine.java
+++ b/app/src/main/java/com/foobnix/tts/TTSEngine.java
@@ -61,6 +61,9 @@ public class TTSEngine {
     private static final String TAG = "TTSEngine";
     private static TTSEngine INSTANCE = new TTSEngine();
     volatile TextToSpeech ttsEngine;
+    private boolean initialized;
+    private String pendingText;
+    private int generation;
     volatile MediaPlayer mp;
     Timer mTimer;
     Object helpObject = new Object();
@@ -137,8 +140,10 @@ public class TTSEngine {
         LOG.d(TAG, "shutdown");
 
         synchronized (helpObject) {
+            generation++;
+            initialized = false;
+            pendingText = null;
             if (ttsEngine != null) {
-
                 ttsEngine.shutdown();
             }
             ttsEngine = null;
@@ -167,19 +172,38 @@ public class TTSEngine {
             if (ttsEngine != null) {
                 return ttsEngine;
             }
-            if (onLisnter == null) {
-                onLisnter = listener;
-            }
+            final OnInitListener callback = onLisnter == null ? listener : onLisnter;
             // The system default engine can point at a package that is no longer installed
             // (Android then logs "is not allowed to bind to private engine" and stays silent).
             // In that case pick an engine that is actually present instead of inheriting the
             // broken default.
             final String fallback = resolveUsableEngine(LibreraApp.context);
+            final int currentGeneration = ++generation;
+            initialized = false;
+            OnInitListener init = status -> {
+                synchronized (helpObject) {
+                    if (generation != currentGeneration) {
+                        return;
+                    }
+                    initialized = status == TextToSpeech.SUCCESS;
+                    if (!initialized) {
+                        pendingText = null;
+                    }
+                }
+                callback.onInit(status);
+                synchronized (helpObject) {
+                    if (generation == currentGeneration && initialized && pendingText != null) {
+                        String queued = pendingText;
+                        pendingText = null;
+                        speekLocked(queued);
+                    }
+                }
+            };
             if (fallback != null) {
                 LOG.d(TAG, "default TTS engine unusable, falling back to", fallback);
-                ttsEngine = new TextToSpeech(LibreraApp.context, onLisnter, fallback);
+                ttsEngine = new TextToSpeech(LibreraApp.context, init, fallback);
             } else {
-                ttsEngine = new TextToSpeech(LibreraApp.context, onLisnter);
+                ttsEngine = new TextToSpeech(LibreraApp.context, init);
             }
         }
 
@@ -254,6 +278,7 @@ public class TTSEngine {
 
         LOG.d(TAG, "stop");
         synchronized (helpObject) {
+            pendingText = null;
 
             if (ttsEngine != null) {
                 if (Build.VERSION.SDK_INT >= 15) {
@@ -271,21 +296,8 @@ public class TTSEngine {
     public void stopDestroy() {
         LOG.d(TAG, "stop");
         TxtUtils.dictHash = "";
-        synchronized (helpObject) {
-            if (ttsEngine != null) {
-                ttsEngine.shutdown();
-            }
-            ttsEngine = null;
-        }
-        AppSP.get().lastBookParagraph = 0;
-    }
-
-    public TextToSpeech setTTSWithEngine(String engine) {
         shutdown();
-        synchronized (helpObject) {
-            ttsEngine = new TextToSpeech(LibreraApp.context, listener, engine);
-        }
-        return ttsEngine;
+        AppSP.get().lastBookParagraph = 0;
     }
 
     @TargetApi(Build.VERSION_CODES.LOLLIPOP) public void speek(final String text) {
@@ -313,24 +325,18 @@ public class TTSEngine {
             LOG.d("getTTS-status not null");
         }
 
-        ttsEngine = getTTS(new OnInitListener() {
-
-            @Override public void onInit(int status) {
-                LOG.d("getTTS-status", status);
-                if (status == TextToSpeech.SUCCESS) {
-                    try {
-                        Thread.sleep(1000);
-                    } catch (InterruptedException e) {
-                    }
-                    speek(text);
-                }
-            }
-        });
+        ttsEngine = getTTS();
 
         if (ttsEngine == null) {
             LOG.d(TAG, "speek: no TTS engine available");
             return;
         }
+        if (!initialized) {
+            LOG.d(TAG, "speek: waiting for TTS initialization");
+            pendingText = text;
+            return;
+        }
+        pendingText = null;
 
         ttsEngine.setPitch(AppState.get().ttsPitch);
         if (AppState.get().ttsSpeed == 0.0f) {

--- a/app/src/main/java/com/foobnix/tts/TTSService.java
+++ b/app/src/main/java/com/foobnix/tts/TTSService.java
@@ -280,13 +280,6 @@ import java.util.List;
             }
             return false;
         }
-        if (TTSEngine.get()
-                     .isInit() && TTSEngine.get()
-                                           .getCurrentLang()
-                                           .equals("---")) {
-            openSettingsIntent(context);
-            return false;
-        }
         return true;
     }
 


### PR DESCRIPTION
Problem: Android initializes TextToSpeech asynchronously. The app mistook an unknown language during initialization for a configuration failure, opened Settings, and could send speech before the engine was ready.

Fix: Track initialization success and queue the first speech request until onInit succeeds. Clear pending speech on stop/shutdown, ignore obsolete engine initialization callbacks, and stop treating an unknown language as a reason to open Settings.

Tested manually by building the app and going through the scenario.

Assisted-by: gpt-5-6-sol